### PR TITLE
Prepare for release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,19 @@ network function.
 
 ## Install dependencies
 
-```
+```bash
 sudo apt install git python3-pip python3-venv python3-setuptools python3-wheel ninja-build build-essential flex bison git libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev meson curl
 python3 -m pip install build
 ```
 
 ## Downloading
 
-Release sdist tar files can be downloaded from _TBC_.
+Release tar files can be downloaded from <https://github.com/5G-MAG/rt-5gms-application-function/releases>.
 
 The source can be obtained by cloning the github repository.
-```
+
+For example to download the latest release you can use:
+```bash
 cd ~
 git clone --recurse-submodules https://github.com/5G-MAG/rt-5gms-application-function.git
 cd rt-5gms-application-function
@@ -39,7 +41,7 @@ git submodule update
 
 To build the 5GMS Application Function from the source: 
 
-``` 
+```bash
 cd ~/rt-5gms-application-function
 meson build --prefix=`pwd`/install
 ninja -C build
@@ -48,7 +50,7 @@ ninja -C build
 ## Installing
 
 To install the built Application Function:
-```
+```bash
 cd ~/rt-5gms-application-function/build
 ninja install
 ```
@@ -56,7 +58,7 @@ ninja install
 ## Running
 
 The Application Function can be executed with the command:
-```
+```bash
 cd ~/rt-5gms-application-function/src/5gmsaf
 ../../install/bin/open5gs-msafd -c msaf.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -109,4 +109,6 @@ curl -v http://127.0.0.22:7777/3gpp-m5/v2/service-access-information/does_not_ex
 
 ## Development
 
-_TODO_
+This project follows the [Gitflow workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow). The
+`development` branch of this project serves as an integration branch for new features. Consequently, please make sure to switch
+to the `development` branch before starting the implementation of a new feature.

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 # https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 
 project('rt-5gms-af', 'c',
-    version : '0.0.1',
+    version : '1.0.0',
     license : '5G-MAG Public',
     meson_version : '>= 0.47.0',
     default_options : [


### PR DESCRIPTION
This fills in the Development section of the main README with the Gitflow details from the rt-5gms-application-server project, improves the source downloading section and bumps the version number to 1.0.0 in preparation for release.