### PR TITLE
Fix: Use domainNameAlias for the authority in the mediaPlayerEntry when available and improve error logging by the 5GMS AF

### DIFF
--- a/src/5gmsaf/media-player-entry.c
+++ b/src/5gmsaf/media-player-entry.c
@@ -23,7 +23,6 @@ char *media_player_entry_create(const char *session_id, OpenAPI_content_hosting_
     static const char macro[] = "{provisioningSessionId}";
     char *url_path_prefix = NULL;
     const char *protocol = "http";
-    msaf_application_server_node_t *msaf_as = NULL;
     char *domain_name;
 
     ogs_assert(session_id);
@@ -45,7 +44,6 @@ char *media_player_entry_create(const char *session_id, OpenAPI_content_hosting_
 
 
     url_path_prefix = url_path_prefix_create(macro, session_id);
-    msaf_as = ogs_list_first(&msaf_self()->config.applicationServers_list); /* just use first defined AS for now - change later to use AS picked from pool */
     media_player_entry = ogs_msprintf("%s://%s%s%s", protocol, domain_name, url_path_prefix, chc->entry_point_path);
 
     ogs_free(url_path_prefix);

--- a/src/5gmsaf/media-player-entry.c
+++ b/src/5gmsaf/media-player-entry.c
@@ -24,6 +24,7 @@ char *media_player_entry_create(const char *session_id, OpenAPI_content_hosting_
     char *url_path_prefix = NULL;
     const char *protocol = "http";
     msaf_application_server_node_t *msaf_as = NULL;
+    char *domain_name;
 
     ogs_assert(session_id);
     ogs_assert(chc);
@@ -36,9 +37,16 @@ char *media_player_entry_create(const char *session_id, OpenAPI_content_hosting_
         }
     }
 
+    if(dist_config->domain_name_alias){
+        domain_name = dist_config->domain_name_alias;
+    } else {
+        domain_name = dist_config->canonical_domain_name;
+    }
+
+
     url_path_prefix = url_path_prefix_create(macro, session_id);
     msaf_as = ogs_list_first(&msaf_self()->config.applicationServers_list); /* just use first defined AS for now - change later to use AS picked from pool */
-    media_player_entry = ogs_msprintf("%s://%s%s%s", protocol, msaf_as->canonicalHostname, url_path_prefix, chc->entry_point_path);
+    media_player_entry = ogs_msprintf("%s://%s%s%s", protocol, domain_name, url_path_prefix, chc->entry_point_path);
 
     ogs_free(url_path_prefix);
 

--- a/src/5gmsaf/msaf-sm.c
+++ b/src/5gmsaf/msaf-sm.c
@@ -505,7 +505,7 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                     msaf_provisioning_session_t *msaf_provisioning_session = NULL;
                                     msaf_provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(message.h.resource.component[1]);
 
-				    if(msaf_provisioning_session) {
+				    if (!msaf_provisioning_session) {
 				        char *err = NULL;
                                         asprintf(&err,"Provisioning Session [%s] not found.", message.h.resource.component[1]);
                                         ogs_error("Client requested invalid Provisioning Session [%s]", message.h.resource.component[1]);
@@ -513,6 +513,8 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                                 404, &message,
                                                 "Provisioning Session not found",
                                                 err));
+                                        ogs_sbi_message_free(&message);
+                                        break;
 				    }
 				    
 				    if (msaf_provisioning_session->serviceAccessInformation) {

--- a/src/5gmsaf/msaf-sm.c
+++ b/src/5gmsaf/msaf-sm.c
@@ -502,20 +502,20 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                 CASE(OGS_SBI_HTTP_METHOD_GET)
                                     cJSON *service_access_information;
 
-                                   msaf_provisioning_session_t *msaf_provisioning_session = NULL;
+                                    msaf_provisioning_session_t *msaf_provisioning_session = NULL;
                                     msaf_provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(message.h.resource.component[1]);
 
-				                    if(msaf_provisioning_session) {
-				                        char *err = NULL;
+				    if(msaf_provisioning_session) {
+				        char *err = NULL;
                                         asprintf(&err,"Provisioning Session [%s] not found.", message.h.resource.component[1]);
                                         ogs_error("Client requested invalid Provisioning Session [%s]", message.h.resource.component[1]);
                                         ogs_assert(true == ogs_sbi_server_send_error(stream,
-                                            404, &message,
-                                            "Provisioning Session not found",
-                                            err));
-				                    }
+                                                404, &message,
+                                                "Provisioning Session not found",
+                                                err));
+				    }
 				    
-				                    if (msaf_provisioning_session->serviceAccessInformation) {
+				    if (msaf_provisioning_session->serviceAccessInformation) {
                                         service_access_information = msaf_context_retrieve_service_access_information(message.h.resource.component[1]);
                                         if (service_access_information != NULL) {
                                             ogs_sbi_response_t *response;
@@ -538,14 +538,14 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                                        "Service Access Information not found",
                                                         err));
                                         }
-				                    } else {
+				    } else {
                                         char *err = NULL;
                                         asprintf(&err,"Provisioning Session [%s] has no Service Access Information associated with it.", message.h.resource.component[1]);
                                         ogs_error("Provisioning Session [%s] has no Service Access Information associated with it", message.h.resource.component[1]);
                                         ogs_assert(true == ogs_sbi_server_send_error(stream,
-                                            404, &message,
-                                            "Service Access Information not found",
-                                            err));
+                                                404, &message,
+                                                "Service Access Information not found",
+                                                err));
                                     }
                                     break;
                                 DEFAULT
@@ -561,9 +561,9 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                     message.h.resource.component[0]);
                             ogs_assert(true ==
                                     ogs_sbi_server_send_error(stream,
-                                        OGS_SBI_HTTP_STATUS_BAD_REQUEST, &message,
-                                        "Invalid resource name",
-                                        message.h.resource.component[0]));
+                                            OGS_SBI_HTTP_STATUS_BAD_REQUEST, &message,
+                                            "Invalid resource name",
+                                            message.h.resource.component[0]));
                     END
                     ogs_sbi_message_free(&message);
                     break;
@@ -571,8 +571,8 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                     ogs_error("Invalid API name [%s]", message.h.service.name);
                     ogs_assert(true ==
                             ogs_sbi_server_send_error(stream,
-                                OGS_SBI_HTTP_STATUS_BAD_REQUEST, &message,
-                                "Invalid API name", message.h.service.name));
+                                    OGS_SBI_HTTP_STATUS_BAD_REQUEST, &message,
+                                    "Invalid API name", message.h.service.name));
                     ogs_sbi_message_free(&message);
             END
             break;

--- a/src/5gmsaf/provisioning-session.c
+++ b/src/5gmsaf/provisioning-session.c
@@ -82,6 +82,13 @@ msaf_provisioning_session_create(char *provisioning_session_type, char *asp_id, 
     msaf_provisioning_session->certificate_map = msaf_certificate_map();
     ogs_hash_set(msaf_self()->provisioningSessions_map, ogs_strdup(msaf_provisioning_session->provisioningSessionId), OGS_HASH_KEY_STRING, msaf_provisioning_session);
 
+#if 1 /* TODO: Remove when content hosting configuration is available via M1 interface */
+    msaf_provisioning_session->contentHostingConfiguration = msaf_content_hosting_configuration_create(msaf_provisioning_session);
+    media_player_entry = media_player_entry_create(msaf_provisioning_session->provisioningSessionId, msaf_provisioning_session->contentHostingConfiguration);
+    ogs_assert(media_player_entry);
+    msaf_provisioning_session->serviceAccessInformation = msaf_context_service_access_information_create(msaf_provisioning_session->provisioningSessionId, media_player_entry);
+#endif
+
     OpenAPI_provisioning_session_free(provisioning_session);
 
     return msaf_provisioning_session;

--- a/src/5gmsaf/provisioning-session.c
+++ b/src/5gmsaf/provisioning-session.c
@@ -373,10 +373,7 @@ msaf_distribution_create(cJSON *content_hosting_config, msaf_provisioning_sessio
 {
     OpenAPI_lnode_t *dist_config_node = NULL;
     OpenAPI_distribution_configuration_t *dist_config = NULL;
-    OpenAPI_distribution_configuration_t *new_dist_config = NULL;
-    OpenAPI_list_t *dist_configs;
     char *url_path;
-    char *base_url;
     char *domain_name;
     char *media_player_entry;
     static const char macro[] = "{provisioningSessionId}";

--- a/src/5gmsaf/provisioning-session.c
+++ b/src/5gmsaf/provisioning-session.c
@@ -458,14 +458,21 @@ msaf_content_hosting_configuration_create(msaf_provisioning_session_t *provision
     url_path = url_path_create(macro, provisioning_session->provisioningSessionId, as_state->application_server);
 
     char *content_host_config_data = read_file(msaf_self()->config.contentHostingConfiguration);
+    if (content_host_config_data == NULL){
+        ogs_error("Reading contentHostingConfiguration failed");
+    }
     cJSON *content_host_config_json = cJSON_Parse(content_host_config_data);
+
+     if (content_host_config_json == NULL){
+        ogs_error("Parsing contentHostingConfiguration to JSON structure failed");
+    }
 
     OpenAPI_content_hosting_configuration_t *content_hosting_configuration
         = OpenAPI_content_hosting_configuration_parseFromJSON(content_host_config_json);
     if (!uri_relative_check(content_hosting_configuration->entry_point_path)) {
         cJSON_Delete(content_host_config_json);
         ogs_free(url_path);
-        ogs_debug(" URI relative check return 0: After reading content_host_config_data: %s", content_host_config_data);
+        ogs_debug("Check for relative URI for entryPointPath fails");
         if (content_hosting_configuration)
             OpenAPI_content_hosting_configuration_free(content_hosting_configuration);
         ogs_free(content_host_config_data);

--- a/src/5gmsaf/service-access-information.c
+++ b/src/5gmsaf/service-access-information.c
@@ -35,7 +35,12 @@ cJSON *msaf_context_retrieve_service_access_information(char *provisioning_sessi
     msaf_provisioning_session_t *provisioning_session_context = NULL;
     provisioning_session_context = msaf_provisioning_session_find_by_provisioningSessionId(provisioning_session_id);
     if (provisioning_session_context == NULL){
+	    ogs_error("Couldn't find the Provisioning Session ID [%s]", provisioning_session_id);    
         return NULL;
+    }
+    if (provisioning_session_context->serviceAccessInformation == NULL){
+       ogs_error("The provisioning Session [%s] does not have an associated Service Access Information");
+       return NULL;
     }
     cJSON *service_access_information = OpenAPI_service_access_information_resource_convertToJSON(provisioning_session_context->serviceAccessInformation);
     return service_access_information;

--- a/src/5gmsaf/service-access-information.c
+++ b/src/5gmsaf/service-access-information.c
@@ -39,7 +39,7 @@ cJSON *msaf_context_retrieve_service_access_information(char *provisioning_sessi
         return NULL;
     }
     if (provisioning_session_context->serviceAccessInformation == NULL){
-       ogs_error("The provisioning Session [%s] does not have an associated Service Access Information");
+       ogs_error("The provisioning Session [%s] does not have an associated Service Access Information", provisioning_session_id);
        return NULL;
     }
     cJSON *service_access_information = OpenAPI_service_access_information_resource_convertToJSON(provisioning_session_context->serviceAccessInformation);


### PR DESCRIPTION
Closes #28 

Also adds a little extra logging around ContentHostingConfiguration reading.
