### PR TITLE
Backport Fix to v1.0.x: Use domainNameAlias for the authority in the mediaPlayerEntry when available and improve error logging by the 5GMS AF

### DIFF
--- a/src/5gmsaf/context.c
+++ b/src/5gmsaf/context.c
@@ -8,6 +8,7 @@ program. If this file is missing then the license can be retrieved from
 https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -19,13 +20,11 @@ int __msaf_log_domain;
 
 static OpenAPI_content_hosting_configuration_t *msaf_context_content_hosting_configuration_create(void);
 static OpenAPI_service_access_information_resource_t *msaf_context_service_access_information_create(char *media_player_entry);
-static msaf_provisioning_session_t *msaf_context_provisioning_session_find_by_provisioningSessionId(char *provisioningSessionId);
 static char *media_player_entry_create(const char *provisioning_session_id, OpenAPI_content_hosting_configuration_t *content_hosting_configuration);
 static char *url_path_prefix_create(const char *macro, const char *session_id);
 static char *read_file(const char *filename);
 static int msaf_context_prepare(void);
 static int msaf_context_validation(void);
-static void msaf_context_get_content_host_config(void);
 static void msaf_context_display(void);
 static int ogs_hash_do_per_value(void *fn, const void *key, int klen, const void *value);
 static void msaf_context_provisioning_session_free(msaf_provisioning_session_t *provisioning_session);
@@ -347,11 +346,16 @@ msaf_context_provisioning_session_set() {
     return msaf_provisioning_session;
 }
 
-cJSON *msaf_context_retrieve_service_access_information(char *provisioning_session_id)
+cJSON *msaf_context_retrieve_service_access_information(const char *provisioning_session_id)
 {
     msaf_provisioning_session_t *provisioning_session_context = NULL;
     provisioning_session_context = msaf_context_provisioning_session_find_by_provisioningSessionId(provisioning_session_id);
-    if (provisioning_session_context == NULL){
+    if (provisioning_session_context == NULL) {
+	ogs_error("Couldn't find the Provisioning Session ID [%s]", provisioning_session_id);
+        return NULL;
+    }
+    if (provisioning_session_context->serviceAccessInformation == NULL) {
+        ogs_error("The provisioning Session [%s] does not have an associated Service Access Information", provisioning_session_id);
         return NULL;
     }
     cJSON *service_access_information = OpenAPI_service_access_information_resource_convertToJSON(provisioning_session_context->serviceAccessInformation);
@@ -396,13 +400,13 @@ void msaf_context_application_server_print_all()
         ogs_info("AS %s %s", msaf_as->canonicalHostname, msaf_as->urlPathPrefixFormat);
 }
 
-/***** Private functions *****/
-
-static msaf_provisioning_session_t *
-msaf_context_provisioning_session_find_by_provisioningSessionId(char *provisioningSessionId)
+msaf_provisioning_session_t *
+msaf_context_provisioning_session_find_by_provisioningSessionId(const char *provisioningSessionId)
 {
     return ogs_hash_get(self->provisioningSessions_map, provisioningSessionId, OGS_HASH_KEY_STRING);
 }
+
+/***** Private functions *****/
 
 static OpenAPI_service_access_information_resource_t *
 msaf_context_service_access_information_create(char *media_player_entry) {
@@ -434,7 +438,7 @@ media_player_entry_create(const char *session_id, OpenAPI_content_hosting_config
     static const char macro[] = "{provisioningSessionId}";
     char *url_path_prefix = NULL;
     const char *protocol = "http";
-    msaf_application_server_node_t *msaf_as = NULL;
+    char *domain_name;
 
     ogs_assert(session_id);
     ogs_assert(chc);
@@ -447,9 +451,17 @@ media_player_entry_create(const char *session_id, OpenAPI_content_hosting_config
 	}
     }
 
+    if (dist_config->domain_name_alias && strlen(dist_config->domain_name_alias) > 0) {
+        domain_name = dist_config->domain_name_alias;
+    } else {
+	msaf_application_server_node_t *msaf_as;
+	msaf_as = ogs_list_first(&self->config.applicationServers_list);
+	ogs_debug("dist_config: %s, msaf_as: %s", dist_config->canonical_domain_name, msaf_as->canonicalHostname);
+        domain_name = msaf_as->canonicalHostname;
+    }
+
     url_path_prefix = url_path_prefix_create(macro, session_id);
-    msaf_as = ogs_list_first(&self->config.applicationServers_list); /* just use first defined AS for now - change later to use AS picked from pool */
-    media_player_entry = ogs_msprintf("%s://%s%s%s", protocol, msaf_as->canonicalHostname, url_path_prefix, self->config.mediaPlayerEntrySuffix);
+    media_player_entry = ogs_msprintf("%s://%s%s%s", protocol, domain_name, url_path_prefix, self->config.mediaPlayerEntrySuffix);
 
     ogs_free(url_path_prefix);
 
@@ -506,7 +518,6 @@ static int msaf_context_validation(void)
 
 static void msaf_context_display()
 {
-    msaf_application_server_node_t *msaf_as = NULL, *next = NULL;
     msaf_provisioning_session_t *provisioning_session_context = NULL;
     provisioning_session_context = msaf_context_provisioning_session_find_by_provisioningSessionId(self->config.provisioningSessionId);
     ogs_assert(provisioning_session_context);
@@ -522,6 +533,11 @@ static char *read_file(const char *filename)
 
     /* open in read binary mode */
     f = fopen(filename,"rb");
+    if (!f) {
+	ogs_error("Failed to open file %s: %s", filename, strerror(errno));
+	return NULL;
+    }
+
     /* get the length */
     fseek(f, 0, SEEK_END);
     len = ftell(f);

--- a/src/5gmsaf/context.h
+++ b/src/5gmsaf/context.h
@@ -65,11 +65,12 @@ extern msaf_context_t *msaf_self(void);
 extern int msaf_context_parse_config(void);
 
 extern msaf_provisioning_session_t *msaf_context_provisioning_session_set(void);
-extern cJSON *msaf_context_retrieve_service_access_information(char *provisioning_session_id);
+extern cJSON *msaf_context_retrieve_service_access_information(const char *provisioning_session_id);
 extern msaf_application_server_node_t *msaf_context_application_server_add(char *canonical_hostname, char *url_path_prefix_format);
 extern void msaf_context_application_server_remove(msaf_application_server_node_t *msaf_as);
 extern void msaf_context_application_server_remove_all(void);
 extern void msaf_context_application_server_print_all(void);
+extern msaf_provisioning_session_t *msaf_context_provisioning_session_find_by_provisioningSessionId(const char *provisioningSessionId);
 
 #ifdef __cplusplus
 }

--- a/src/5gmsaf/meson.build
+++ b/src/5gmsaf/meson.build
@@ -175,8 +175,7 @@ libmsaf_dep = declare_dependency(
 
 msaf_sources = files('''
     app.c
-    ../../subprojects/open5gs/src/main.c
-'''.split())
+'''.split()) + open5gs_project.get_variable('app_main_c')
 
 executable('open5gs-msafd',
     sources : msaf_sources,

--- a/subprojects/patch_open5gs.sh
+++ b/subprojects/patch_open5gs.sh
@@ -32,6 +32,17 @@ if ! grep -q '/\* rt-5gms-applicatiopn-function patch applied \*/' "$open5gs_src
          ogs_sbi_server_actions = ogs_mhd_server_actions;
  #endif
      }
+--- open5gs.orig/src/meson.build
++++ open5gs/src/meson.build
+@@ -29,6 +29,8 @@ version_conf = configuration_data()
+ version_conf.set_quoted('OPEN5GS_VERSION', package_version)
+ configure_file(output : 'version.h', configuration : version_conf)
+
++app_main_c = files(['main.c'])
++
+ subdir('mme')
+ subdir('hss')
+ subdir('sgwc')
 EOF
 )
 fi


### PR DESCRIPTION
This backports, to the v1.0.x branch, the use of domainNameAlias in the Service Access Information and improves the error logging around loading the ContentHostingConfiguration and serving the ServiceAccessInformation.

Fixes #28.