### PR TITLE
Enhancement: improved logging around content hosting configuration and certificates configuration files

### DIFF
--- a/src/5gmsaf/application-server-context.c
+++ b/src/5gmsaf/application-server-context.c
@@ -170,6 +170,11 @@ void next_action_for_application_server(msaf_application_server_state_node_t *as
         provisioning_session = strtok_r(upload_cert_id,":",&cert_id);
         upload_cert_filename = msaf_get_certificate_filename(provisioning_session, cert_id);
         data = read_file(upload_cert_filename);
+
+         if(!data) {
+            ogs_error("The certificate file [%s] referenced in the JSON cannot be read", upload_cert_filename);
+        }
+
         component = ogs_msprintf("certificates/%s:%s", provisioning_session, cert_id);
 
         if (cert_id_node) {
@@ -205,7 +210,19 @@ void next_action_for_application_server(msaf_application_server_state_node_t *as
         chc_with_af_unique_cert_id = msaf_content_hosting_configuration_with_af_unique_cert_id(provisioning_session);
 
         json = OpenAPI_content_hosting_configuration_convertToJSON(chc_with_af_unique_cert_id);
+
+         if(!json) {
+            ogs_error("OpenAPI function is not able to convert The contentHostingConfiguration to JSON");
+
+        }
+
         data = cJSON_Print(json);
+
+        if(!data) {
+            ogs_error("The contentHostingConfiguration cannot be parsed");
+
+        }
+
 
         component = ogs_msprintf("content-hosting-configurations/%s", upload_chc->state);
 

--- a/src/5gmsaf/context.c
+++ b/src/5gmsaf/context.c
@@ -50,6 +50,8 @@ void msaf_context_init(void)
 
     ogs_list_init(&self->application_server_states);
 
+    ogs_assert(self->config.contentHostingConfiguration);
+
     self->provisioningSessions_map = ogs_hash_make();
 
     ogs_assert(self->provisioningSessions_map);

--- a/src/5gmsaf/context.c
+++ b/src/5gmsaf/context.c
@@ -50,8 +50,6 @@ void msaf_context_init(void)
 
     ogs_list_init(&self->application_server_states);
 
-    ogs_assert(self->config.contentHostingConfiguration);
-
     self->provisioningSessions_map = ogs_hash_make();
 
     ogs_assert(self->provisioningSessions_map);

--- a/src/5gmsaf/msaf-sm.c
+++ b/src/5gmsaf/msaf-sm.c
@@ -55,7 +55,10 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                 msaf_provisioning_session_t *ps;
                 ps = msaf_provisioning_session_create("DOWNLINK", NULL, "5GMS-AF internal");
                 ogs_info("Provisioning session = %s", ps->provisioningSessionId);
+                ogs_assert(msaf_self()->config.contentHostingConfiguration);
             }
+
+            
             break;
 
         case OGS_FSM_EXIT_SIG:

--- a/src/5gmsaf/provisioning-session.c
+++ b/src/5gmsaf/provisioning-session.c
@@ -303,7 +303,7 @@ msaf_certificate_map(void)
     }
     path = get_path(msaf_self()->config.certificate);
     if (!path) {
-        ogs_error("The Application Function could not get of the path certificate file.");
+        ogs_error("The Application Function could not get path of the certificate file.");
     }
     ogs_assert(path);
     cJSON_ArrayForEach(entry, cert) {
@@ -365,7 +365,7 @@ msaf_retrieve_certificates_from_map(msaf_provisioning_session_t *provisioning_se
                     certificate->state = provisioning_session_id_plus_cert_id;
                     ogs_list_add(certs, certificate);
                 } else {
-                    ogs_error("Certificate [%s] not found for Content Hosting Configuration [%s]", dist_config->certificate_id, provisioning_session->provisioningSessionId);
+                    ogs_error("Certificate id [%s] not found for Content Hosting Configuration [%s]", dist_config->certificate_id, provisioning_session->provisioningSessionId);
                     resource_id_node_t *next;
                     ogs_list_for_each_safe(certs, next, certificate) {
                         ogs_list_remove(certs, certificate);
@@ -480,6 +480,12 @@ msaf_content_hosting_configuration_create(msaf_provisioning_session_t *provision
     msaf_application_server_state_node_t *as_state;
     char *domain_name;
 
+    if(!msaf_self()->config.contentHostingConfiguration) {
+        ogs_error("contentHostingConfiguration not present in the MSAF configuration file");
+    }
+
+    ogs_assert(msaf_self()->config.contentHostingConfiguration);
+
     as_state = ogs_list_first(&msaf_self()->application_server_states);
 
     url_path = url_path_create(macro, provisioning_session->provisioningSessionId, as_state->application_server);
@@ -488,11 +494,16 @@ msaf_content_hosting_configuration_create(msaf_provisioning_session_t *provision
     if (content_host_config_data == NULL){
         ogs_error("Reading contentHostingConfiguration failed");
     }
+
+    ogs_assert(content_host_config_data);
+
     cJSON *content_host_config_json = cJSON_Parse(content_host_config_data);
 
      if (content_host_config_json == NULL){
         ogs_error("Parsing contentHostingConfiguration to JSON structure failed");
     }
+
+    ogs_assert(content_host_config_json);
 
     OpenAPI_content_hosting_configuration_t *content_hosting_configuration
         = OpenAPI_content_hosting_configuration_parseFromJSON(content_host_config_json);

--- a/src/5gmsaf/utilities.c
+++ b/src/5gmsaf/utilities.c
@@ -8,6 +8,7 @@ program. If this file is missing then the license can be retrieved from
 https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 */
 
+#include <errno.h>
 #include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -23,7 +24,7 @@ char *read_file(const char *filename)
     /* open in read binary mode */
     f = fopen(filename, "rb");
     if (f == NULL) {
-	ogs_error("Unable to open file with name [%s]", filename);
+	ogs_error("Unable to open file with name [%s]: %s", filename, strerror(errno));
 	return NULL;
     }
     /* get the length */
@@ -46,7 +47,7 @@ char *get_path(const char *file)
 
     path = realpath(file, NULL);
     if(path == NULL){
-        ogs_error("cannot find file with name[%s]", file);
+        ogs_error("cannot find file with name[%s]: %s", file, strerror(errno));
         return NULL;
     }
     file_dir = ogs_strdup(dirname(path));


### PR DESCRIPTION
This PR applies some changes to improve logging around the reading and parsing of the ContentHostingConfiguration and Certificates JSON files as referred to from the `msaf.yaml` file.

Implements #29 for the development branch.

Improves logging around:
- missing configuration file settings for `msaf/certificates` and `msaf/contentHostingConfiguration`.
- Problems opening the configured files.
- Problems parsing the configured files.
- Problems allocating memory for the parsed data structures.
- Problems validating the consistency of the configuration.