### PR TITLE
Prepare release candidate for v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ be `rt-5gms-application-function/src/5gmsaf/msaf.yaml`.
 ## Testing with the example configuration
 
 If you started the 5GMS Application Function with the example configuration (`msaf.yaml`), you can test it by retrieving
-http://127.0.0.22:7777/3gpp-m5/v2/service-access-information/d54a1fcc-d411-4e32-807b-2c60dbaeaf5f.
+http://127.0.0.22:7777/3gpp-m5/v2/service-access-information/_{provisioning-session-id}_. Where _{provisioning-session-id}_
+is the provisioning session ID reported by the 5GMS Application Function in its log.
 
 For example:
 
@@ -107,52 +108,6 @@ curl -v http://127.0.0.22:7777/3gpp-m5/v2/service-access-information/does_not_ex
 
 ...which would receive a response like:
 
-```
-< HTTP/1.1 404 Not Found
-< Date: Fri, 28 Oct 2022 16:26:28 GMT
-< Connection: close
-< Content-Type: application/problem+json
-< Content-Length: 218
-< 
-{
-	"type":	"/3gpp-m5/v2",
-	"title":	"Service Access Information not found",
-	"status":	404,
-	"detail":	"Service Access Information does_not_exist not found.",
-	"instance":	"/service-access-information/does_not_exist"
-}
-```
-
-## Testing with the example configuration
-
-If you started the 5GMS Application Function with the example configuration, you can test it by retrieving {http://127.0.0.22:7778/3gpp-m5/v2/service-access-information/d54a1fcc-d411-4e32-807b-2c60dbaeaf5f}.
-
-For example:
-```bash
-curl -H 'User-Agent: AF' -v http://127.0.0.22:7778/3gpp-m5/v2/service-access-information/d54a1fcc-d411-4e32-807b-2c60dbaeaf5f
-```
-...would receive a response like:
-```
-< HTTP/1.1 200 OK
-< Date: Fri, 28 Oct 2022 16:26:09 GMT
-< Connection: close
-< Content-Type: application/json
-< Content-Length: 278
-< 
-{
-	"provisioningSessionId":	"d54a1fcc-d411-4e32-807b-2c60dbaeaf5f",
-	"provisioningSessionType":	"DOWNLINK",
-	"streamingAccess":	{
-		"mediaPlayerEntry":	"https://localhost/m4d/provisioning-session-d54a1fcc-d411-4e32-807b-2c60dbaeaf5f/BigBuckBunny_4s_onDemand_2014_05_09.mpd"
-	}
-}
-```
-
-The not found response can be tested using a different string to the provisioningSessionId set in the configuration YAML file. For example
-```bash
-curl -H 'User-Agent: AF' -v http://127.0.0.22:7778/3gpp-m5/v2/service-access-information/does_not_exist
-```
-...which would receive a response like:
 ```
 < HTTP/1.1 404 Not Found
 < Date: Fri, 28 Oct 2022 16:26:28 GMT

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 # https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 
 project('rt-5gms-af', 'c',
-    version : '1.0.0',
+    version : '1.1.0',
     license : '5G-MAG Public',
     meson_version : '>= 0.47.0',
     default_options : [


### PR DESCRIPTION
The introduction of the M3 interface marks a significant change in the operation of the 5GMS Application Function, so bumping the version to v1.1.0 for the next release.

I'll tag a release candidate for this when the changes from 5G-MAG/rt-5gms-application-server#55 have been merged.