### PR TITLE
Bump version for v1.0.1 release.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 # https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 
 project('rt-5gms-af', 'c',
-    version : '1.0.0',
+    version : '1.0.1',
     license : '5G-MAG Public',
     meson_version : '>= 0.47.0',
     default_options : [


### PR DESCRIPTION
This prepares for a release of v1.0.1 which includes:
- Improved error logging
- Fix for the domain name used in the M5 ServiceAccessInformation response so that it uses the `domainNameAlias` provided in the ContentHostingConfiguration rather than the canonical hostname of the 5GMS Application Server.
- Build time fixes for sandboxing issues
- Use public URL for rt-common-shared submodule
- Minor documentation fixes.