### PR TITLE
Documentation and deployment updates for v1.1.0 release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ninja -C build
 
 ## Installing
 
-To install the built Application Function:
+To install the built Application Function as a system process:
 
 ```bash
 cd ~/rt-5gms-application-function/build

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository holds the 5GMS Application Function implementation for the 5G-MA
 
 ## Introduction
 
-The 5GMS application function (AF) is a Network Function that forms part of the 5G Media Services framework as defined
+The 5GMS application function (AF) is a Network Function that forms part of the 5G Media Streaming framework as defined
 in ETSI TS 126.501.
 
 This AF uses the [Open5GS](https://open5gs.org/) framework to implement the network function.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ This AF uses the [Open5GS](https://open5gs.org/) framework to implement the netw
 
 ## Specifications
 
-* [ETSI TS 126 501](https://portal.etsi.org/webapp/workprogram/Report_WorkItem.asp?WKI_ID=66447) - 5G Media Streaming (
-  5GMS): General description and architecture (3GPP TS 26.501 version 17.2.0 Release 17)
-* [ETSI TS 126 512](https://portal.etsi.org/webapp/workprogram/Report_WorkItem.asp?WKI_ID=66919) - 5G Media Streaming (
-  5GMS): Protocols (3GPP TS 26.512 version 17.1.2 Release 17)
+* [ETSI TS 126 501](https://portal.etsi.org/webapp/workprogram/Report_WorkItem.asp?WKI_ID=67203) - 5G Media Streaming (
+  5GMS): General description and architecture (3GPP TS 26.501 version 17.3.0 Release 17)
+* [ETSI TS 126 512](https://portal.etsi.org/webapp/workprogram/Report_WorkItem.asp?WKI_ID=67679) - 5G Media Streaming (
+  5GMS): Protocols (3GPP TS 26.512 version 17.3.0 Release 17)
 
 ## Install dependencies
 
@@ -59,6 +59,8 @@ ninja install
 
 ## Running
 
+The Application Function requires a [5GMS Application Server](https://github.com/5G-MAG/rt-5gms-application-server) (release v1.1.0 or above) to be running. Please follow the [instructions](https://github.com/5G-MAG/rt-5gms-application-server/tree/development#readme) for installing and running the 5GMS Application Server before starting the Application Function.
+
 The Application Function can be executed with the command:
 
 ```bash
@@ -67,7 +69,7 @@ cd ~/rt-5gms-application-function/src/5gmsaf
 ```
 
 Use `-c` to specify a configuration file. The example configuration file can
-be `rt-5gms-application-function/src/5gmsaf/msaf.yaml`.
+be found in `rt-5gms-application-function/src/5gmsaf/msaf.yaml`.
 
 ## Testing with the example configuration
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To build the 5GMS Application Function from the source:
 
 ```bash
 cd ~/rt-5gms-application-function
-meson build --prefix=`pwd`/install
+meson build
 ninja -C build
 ```
 
@@ -54,7 +54,7 @@ To install the built Application Function:
 
 ```bash
 cd ~/rt-5gms-application-function/build
-ninja install
+sudo meson install --no-rebuild
 ```
 
 ## Running
@@ -64,23 +64,30 @@ The Application Function requires a [5GMS Application Server](https://github.com
 The Application Function can be executed with the command:
 
 ```bash
-cd ~/rt-5gms-application-function/src/5gmsaf
-../../install/bin/open5gs-msafd -c msaf.yaml
+/usr/local/bin/open5gs-msafd
 ```
 
-Use `-c` to specify a configuration file. The example configuration file can
-be found in `rt-5gms-application-function/src/5gmsaf/msaf.yaml`.
+This uses the installed configuration file at `/usr/local/etc/open5gs/msaf.yaml`. You can use the `-c` command line parameter to
+specify an alternative configuration file. For example:
+
+```bash
+/usr/local/bin/open5gs-msafd -c alternate-msaf.yaml
+```
+
+The source example configuration file can be found in `~/rt-5gms-application-function/src/5gmsaf/msaf.yaml`.
 
 ## Testing with the example configuration
 
-If you started the 5GMS Application Function with the example configuration (`msaf.yaml`), you can test it by retrieving
-http://127.0.0.22:7777/3gpp-m5/v2/service-access-information/_{provisioning-session-id}_. Where _{provisioning-session-id}_
+### Testing the M5 interface
+
+If you started the 5GMS Application Function with the default configuration (`msaf.yaml`), you can test it by retrieving
+`http://localhost:7778/3gpp-m5/v2/service-access-information/{provisioning-session-id}`. Where `{provisioning-session-id}`
 is the provisioning session ID reported by the 5GMS Application Function in its log.
 
 For example:
 
 ```bash
-curl -v http://127.0.0.22:7777/3gpp-m5/v2/service-access-information/d54a1fcc-d411-4e32-807b-2c60dbaeaf5f
+curl -v http://localhost:7778/3gpp-m5/v2/service-access-information/0f9e5e28-a3c5-41ed-8dd9-432c02738477
 ```
 
 ...would receive a response like:
@@ -93,10 +100,10 @@ curl -v http://127.0.0.22:7777/3gpp-m5/v2/service-access-information/d54a1fcc-d4
 < Content-Length: 278
 < 
 {
-	"provisioningSessionId":	"d54a1fcc-d411-4e32-807b-2c60dbaeaf5f",
+	"provisioningSessionId":	"0f9e5e28-a3c5-41ed-8dd9-432c02738477",
 	"provisioningSessionType":	"DOWNLINK",
 	"streamingAccess":	{
-		"mediaPlayerEntry":	"https://localhost/m4d/provisioning-session-d54a1fcc-d411-4e32-807b-2c60dbaeaf5f/BigBuckBunny_4s_onDemand_2014_05_09.mpd"
+		"mediaPlayerEntry":	"http://localhost/m4d/provisioning-session-0f9e5e28-a3c5-41ed-8dd9-432c02738477/BigBuckBunny_4s_onDemand_2014_05_09.mpd"
 	}
 }
 ```
@@ -105,7 +112,7 @@ The not found response can be tested using a different provisioningSessionId str
 provisioningSessionId key in the configuration YAML file. For example:
 
 ```bash
-curl -v http://127.0.0.22:7777/3gpp-m5/v2/service-access-information/does_not_exist
+curl -v http://localhost:7778/3gpp-m5/v2/service-access-information/does_not_exist
 ```
 
 ...which would receive a response like:
@@ -125,6 +132,63 @@ curl -v http://127.0.0.22:7777/3gpp-m5/v2/service-access-information/does_not_ex
 	"instance":	"/service-access-information/does_not_exist"
 }
 ```
+
+### Testing the M3 interface
+
+To see the M3 operations taking place you will need to increase logging level to `debug` by setting the `logging.level` property in the `msaf.yaml` file. For example:
+
+```yaml
+logging:
+    level: debug
+    domain: msaf
+```
+
+With the logging at `debug` level, the Application Function will report significant communications with the Application Server in
+its log output. For example:
+
+```
+Open5GS daemon v2.4.11-31-gf1c0b6d+
+02/03 13:17:08.426: [app] INFO: Configuration: '/usr/local/etc/open5gs/msaf.yaml' (../subprojects/open5gs/lib/app/ogs-init.c:126)
+02/03 13:17:08.427: [sbi] INFO: mhd_server() [0.0.0.0]:7778 (../subprojects/open5gs/lib/sbi/mhd-server.c:279)
+02/03 13:17:08.427: [msaf] DEBUG: msaf_state_initial(): INIT (../src/5gmsaf/msaf-sm.c:20)
+02/03 13:17:08.427: [msaf] DEBUG: msaf_state_functional(): ENTRY (../src/5gmsaf/msaf-sm.c:47)
+02/03 13:17:08.427: [msaf] INFO: [0f9e57de-a3c5-41ed-8dd9-432c02738477] MSAF Running (../src/5gmsaf/msaf-sm.c:53)
+02/03 13:17:08.427: [msaf] DEBUG: BigBuckBunny_4s_onDemand_2014_05_09.mpd matches the regular expression (../src/5gmsaf/provisioning-session.c:592)
+02/03 13:17:08.427: [msaf] DEBUG: Distribution URL: http://msaf01.example.net/m4d/ (../src/5gmsaf/provisioning-session.c:540)
+02/03 13:17:08.427: [app] INFO: 5GMSAF initialize...done (../src/5gmsaf/app.c:24)
+02/03 13:17:08.427: [msaf] INFO: Provisioning session = 0f9e5e28-a3c5-41ed-8dd9-432c02738477 (../src/5gmsaf/msaf-sm.c:57)
+02/03 13:17:08.473: [msaf] DEBUG: msaf_state_functional(): OGS_EVENT_NAME_SBI_CLIENT (../src/5gmsaf/msaf-sm.c:47)
+02/03 13:17:08.473: [msaf] DEBUG: [certificates] Method [GET] with Response [200] received (../src/5gmsaf/msaf-sm.c:1111)
+02/03 13:17:08.473: [msaf] DEBUG: Adding certificate [8578424e-9cae-41ed-9e7a-f3a3ae58dd9b:dn01] to Current certificates (../src/5gmsaf/msaf-sm.c:1139)
+02/03 13:17:08.473: [msaf] DEBUG: Adding certificate [30d46048-a3c4-41ed-86b2-7b1b5377721f:dn01] to Current certificates (../src/5gmsaf/msaf-sm.c:1139)
+02/03 13:17:08.473: [msaf] DEBUG: Adding certificate [bf5fc424-a3c4-41ed-be95-b7864fdc6a53:dn01] to Current certificates (../src/5gmsaf/msaf-sm.c:1139)
+02/03 13:17:08.474: [msaf] DEBUG: msaf_state_functional(): OGS_EVENT_NAME_SBI_CLIENT (../src/5gmsaf/msaf-sm.c:47)
+02/03 13:17:08.474: [msaf] DEBUG: [content-hosting-configurations] Method [GET] with Response [200] for Content Hosting Configuration operation [(null)] (../src/5gmsaf/msaf-sm.c:888)
+02/03 13:17:08.474: [msaf] DEBUG: Adding [8578424e-9cae-41ed-9e7a-f3a3ae58dd9b] to the current Content Hosting Configuration list (../src/5gmsaf/msaf-sm.c:913)
+02/03 13:17:08.474: [msaf] DEBUG: Adding [30d46048-a3c4-41ed-86b2-7b1b5377721f] to the current Content Hosting Configuration list (../src/5gmsaf/msaf-sm.c:913)
+02/03 13:17:08.474: [msaf] DEBUG: Adding [bf5fc424-a3c4-41ed-be95-b7864fdc6a53] to the current Content Hosting Configuration list (../src/5gmsaf/msaf-sm.c:913)
+02/03 13:17:08.474: [msaf] DEBUG: M3 client: Sending POST method to Application Server [localhost] for Content Hosting Configuration:  [0f9e5e28-a3c5-41ed-8dd9-432c02738477] (../src/5gmsaf/application-server-context.c:233)
+02/03 13:17:08.517: [msaf] DEBUG: msaf_state_functional(): OGS_EVENT_NAME_SBI_CLIENT (../src/5gmsaf/msaf-sm.c:47)
+02/03 13:17:08.517: [msaf] DEBUG: [content-hosting-configurations] Method [POST] with Response [201] recieved for Content Hosting Configuration [0f9e5e28-a3c5-41ed-8dd9-432c02738477] (../src/5gmsaf/msaf-sm.c:736)
+02/03 13:17:08.517: [msaf] DEBUG: Removing 0f9e5e28-a3c5-41ed-8dd9-432c02738477 from upload_content_hosting_configurations (../src/5gmsaf/msaf-sm.c:745)
+02/03 13:17:08.517: [msaf] DEBUG: Adding 0f9e5e28-a3c5-41ed-8dd9-432c02738477 to current_content_hosting_configurations (../src/5gmsaf/msaf-sm.c:747)
+```
+
+The above log shows the Application Function learning that the Application Server already knows about 3 certificates (`8578424e-9cae-41ed-9e7a-f3a3ae58dd9b:dn01`, `30d46048-a3c4-41ed-86b2-7b1b5377721f:dn01` and `bf5fc424-a3c4-41ed-be95-b7864fdc6a53:dn01`), it then learns that it has 3 content-hosting-configurations (`8578424e-9cae-41ed-9e7a-f3a3ae58dd9b`, `30d46048-a3c4-41ed-86b2-7b1b5377721f` and `bf5fc424-a3c4-41ed-be95-b7864fdc6a53`), and finally it uploads the new content hosting configuration to the AS (`0f9e5e28-a3c5-41ed-8dd9-432c02738477`).
+
+The log of the Application Server can also be checked for communications with the AF:
+
+```
+INFO:rt-5gms-as:Getting list of certificates...
+[2023-02-03 13:17:08 +0000] [28235] [INFO] 127.0.0.1:49538 - - [03/Feb/2023:13:17:08 +0000] "GET /3gpp-m3/v1/certificates 2" 200 208 "-" "-"
+INFO:rt-5gms-as:Getting list of content hosting configurations...
+[2023-02-03 13:17:08 +0000] [28235] [INFO] 127.0.0.1:49538 - - [03/Feb/2023:13:17:08 +0000] "GET /3gpp-m3/v1/content-hosting-configurations 2" 200 247 "-" "-"
+INFO:rt-5gms-as:Adding content hosting configuration 0f9e5e28-a3c5-41ed-8dd9-432c02738477...
+INFO:rt-5gms-as:Reloading proxy daemon...
+[2023-02-03 13:17:08 +0000] [28235] [INFO] 127.0.0.1:49546 - - [03/Feb/2023:13:17:08 +0000] "POST /3gpp-m3/v1/content-hosting-configurations/0f9e5e28-a3c5-41ed-8dd9-432c02738477 2" 201 0 "-" "-"
+```
+
+These log lines from the Application Server can be seen to match the requests in the Application Function log.
 
 ## Development
 

--- a/src/5gmsaf/meson.build
+++ b/src/5gmsaf/meson.build
@@ -13,6 +13,10 @@ libsbi_dep = open5gs_project.get_variable('libsbi_dep')
 open5gs_sysconfdir = open5gs_project.get_variable('open5gs_sysconfdir')
 srcinc = open5gs_project.get_variable('srcinc')
 libdir = open5gs_project.get_variable('libdir')
+python3_exe = open5gs_project.get_variable('python3_exe')
+mkdir_p = open5gs_project.get_variable('mkdir_p')
+install_conf = open5gs_project.get_variable('install_conf')
+
 libmsaf_dist_sources = files('''
     context.c
     context.h
@@ -189,6 +193,10 @@ msaf_sources = files('''
     app.c
 '''.split()) + open5gs_project.get_variable('app_main_c')
 
+msaf_config_source = '''
+    msaf.yaml
+'''.split()
+
 executable('open5gs-msafd',
     sources : msaf_sources,
     c_args : '-DDEFAULT_CONFIG_FILENAME="@0@/msaf.yaml"'.format(open5gs_sysconfdir),
@@ -196,3 +204,9 @@ executable('open5gs-msafd',
     dependencies : [libmsaf_dep],
     install_rpath : libdir,
     install : true)
+
+meson.add_install_script(python3_exe, '-c', mkdir_p.format(open5gs_sysconfdir))
+foreach conf_file : msaf_config_source
+    gen = configure_file(input : conf_file, copy : true, output : conf_file)
+    meson.add_install_script(python3_exe, '-c', install_conf.format(gen, open5gs_sysconfdir))
+endforeach

--- a/src/5gmsaf/msaf.yaml
+++ b/src/5gmsaf/msaf.yaml
@@ -132,16 +132,15 @@ logger:
 msaf:
     open5gsIntegration: false
     sbi:
-      - addr: 127.0.0.22
-        port: 7777
+      - addr: 0.0.0.0
+        port: 7778
     applicationServers:
       - canonicalHostname: localhost
         urlPathPrefixFormat: /m4d/provisioning-session-{provisioningSessionId}/
         m3Port: 7777
-    # The following parameters are only needed for MVP#2 and will be automated
-    # in future.
+    # The following parameters are only needed until M1 is implemented.
     certificate: ../../examples/Certificates.json
-    contentHostingConfiguration: ../../examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_http_and_https.json
+    contentHostingConfiguration: ../../examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json
 #
 # nrf:
 #


### PR DESCRIPTION
This request includes updates for the documentation to reflect the use of 5GMS v17.3.0 specifications and some details about requiring the 5GMS Application Server to be running.

This will also deploy the default `msaf.yaml` file when the install step of the build is done. This follows the Open5GS method of deploying these configuration files. This means that the configuration file will only be deployed, on install, if you are not deploying to a packager (i.e. `DESTDIR` environment variable is not set) and the configuration file does not already exist in the deployment location (this is to prevent customised configuration files being overwritten on subsequent deployments).