### PR TITLE
Improve examples and logging

### DIFF
--- a/examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_domain-name_http.json
+++ b/examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_domain-name_http.json
@@ -1,0 +1,12 @@
+{
+  "name": "Big Buck Bunny",
+  "entryPointPath": "BigBuckBunny_4s_onDemand_2014_05_09.mpd",
+  "ingestConfiguration": {
+    "pull": true,
+    "protocol": "urn:3gpp:5gms:content-protocol:http-pull-ingest",
+    "baseURL": "https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/"
+  },
+  "distributionConfigurations": [
+    {"domainNameAlias": "media.example.com"}
+  ]
+}

--- a/examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_domain-name_http_and_https.json
+++ b/examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_domain-name_http_and_https.json
@@ -1,0 +1,18 @@
+{
+  "name": "Big Buck Bunny",
+  "entryPointPath": "BigBuckBunny_4s_onDemand_2014_05_09.mpd",
+  "ingestConfiguration": {
+    "pull": true,
+    "protocol": "urn:3gpp:5gms:content-protocol:http-pull-ingest",
+    "baseURL": "https://ftp.itec.aau.at/datasets/DASHDataset2014/BigBuckBunny/4sec/"
+  },
+  "distributionConfigurations": [
+    {
+      "domainNameAlias": "media.example.com"
+    },
+    {
+      "domainNameAlias": "media.example.com",
+      "certificateId": "testcert1"
+    }
+  ]
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,12 +9,12 @@ certificate IDs in this file are used to find the matching certificate file
 (containing a public certificate, private key and any intermediate CA
 certificates) when referenced from a ContentHostingConfiguration file.
 
-The `subprojects/rt-common-shared/5gms/scripts/make_self_signed_certs.py` script can be used, passing a ContentHostingConfiguration and this `Certificates.json` file as parameters, to create suitable self-signed certificate files for testing purposes.
+The `subprojects/rt-common-shared/5gms/scripts/make_self_signed_certs.py` script can be used, passing a 5GMS Application Function YAML configuration file as a parameter, to create suitable self-signed certificate files for testing purposes.
 
 For example:
 ```bash
 cd ~/rt-5gms-application-function
-subprojects/rt-common-shared/5gms/scripts/make_self_signed_certs.py examples/ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_https.json examples/Certificates.json
+subprojects/rt-common-shared/5gms/scripts/make_self_signed_certs.py --af-conf=examples/Test_https_canonical-msaf.yaml
 ```
 
 ## `ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json`
@@ -32,3 +32,31 @@ This file is an alternative to `ContentHostingConfiguration_Big-Buck-Bunny_pull-
 ## `ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_https.json`
 
 This file is an alternative to `ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json` (see above) and can be used along with the `Certificates.json` file to run a rt-5gms-application-function to provision a 5GMS Application Server which will provide an HTTPS distribution point only.
+
+## `ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_domain-name_http.json`
+
+This file is the same as `ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json` except that the distribution configuration also has "media.example.com" as a domain name alias. This file is included for testing the portions of the Application Function that should prefer the use of the domain name alias over the canonical name or vice-versa.
+
+## `ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_domain-name_http_and_https.json`
+
+This file is the same as `ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_http_and_https.json` except that the distribution configuration also has "media.example.com" as a domain name alias. This file is included for testing the portions of the Application Function that should prefer the use of the domain name alias over the canonical name or vice-versa.
+
+## `Test_http_canonical-msaf.yaml`
+
+This is a 5GMS Application Function YAML configuration file used for testing. This configuration uses the `ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json` ContentHostingConfiguration to test http protocol distribution using `localhost` as the canonical domain name of the Application Server.
+
+## `Test_http_domain_alias-msaf.yaml`
+
+This is a 5GMS Application Function YAML configuration file used for testing. This configuration uses the `ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_domain-name_http.json` ContentHostingConfiguration to test http protocol distribution using `localhost` as the canonical domain name of the Application Server and `media.example.com` as a domain name alias for the distribution configuration.
+
+## `Test_https_canonical-msaf.yaml`
+
+This is a 5GMS Application Function YAML configuration file used for testing. This configuration uses the `ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_http_and_https.json` ContentHostingConfiguration and the `Certificates.json` certificates index file to test https protocol distribution using `localhost` as the canonical domain name of the Application Server.
+
+Generate the certificates before using the configuration file. See [`Certificates.json`](#certificatesjson) for more information.
+
+## `Test_https_domain_alias-msaf.yaml`
+
+This is a 5GMS Application Function YAML configuration file used for testing. This configuration uses the `ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_domain-name_http_and_https.json` ContentHostingConfiguration and the `Certificates.json` certificates index file to test https protocol distribution using `localhost` as the canonical domain name of the Application Server and `media.example.com` as a domain name alias for the distribution configurations.
+
+Generate the certificates before using the configuration file. See [`Certificates.json`](#certificatesjson) for more information.

--- a/examples/Test_http_canonical-msaf.yaml
+++ b/examples/Test_http_canonical-msaf.yaml
@@ -1,0 +1,28 @@
+logger:
+  level: debug
+  domain: msaf
+
+msaf:
+    open5gsIntegration: false
+    sbi:
+      - addr: 0.0.0.0
+        port: 7778
+    applicationServers:
+      - canonicalHostname: localhost
+        urlPathPrefixFormat: /m4d/provisioning-session-{provisioningSessionId}/
+        m3Port: 7777
+    certificate: Certificates.json
+    contentHostingConfiguration: ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest.json
+
+nrf:
+    sbi:
+      - addr:
+          - 127.0.0.10
+          - ::1
+        port: 7777
+
+parameter:
+
+max:
+
+time:

--- a/examples/Test_http_domain_alias-msaf.yaml
+++ b/examples/Test_http_domain_alias-msaf.yaml
@@ -1,0 +1,28 @@
+logger:
+  level: debug
+  domain: msaf
+
+msaf:
+    open5gsIntegration: false
+    sbi:
+      - addr: 0.0.0.0
+        port: 7778
+    applicationServers:
+      - canonicalHostname: localhost
+        urlPathPrefixFormat: /m4d/provisioning-session-{provisioningSessionId}/
+        m3Port: 7777
+    certificate: Certificates.json
+    contentHostingConfiguration: ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_domain-name_http.json
+
+nrf:
+    sbi:
+      - addr:
+          - 127.0.0.10
+          - ::1
+        port: 7777
+
+parameter:
+
+max:
+
+time:

--- a/examples/Test_https_canonical-msaf.yaml
+++ b/examples/Test_https_canonical-msaf.yaml
@@ -1,0 +1,28 @@
+logger:
+  level: debug
+  domain: msaf
+
+msaf:
+    open5gsIntegration: false
+    sbi:
+      - addr: 0.0.0.0
+        port: 7778
+    applicationServers:
+      - canonicalHostname: localhost
+        urlPathPrefixFormat: /m4d/provisioning-session-{provisioningSessionId}/
+        m3Port: 7777
+    certificate: Certificates.json
+    contentHostingConfiguration: ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_http_and_https.json
+
+nrf:
+    sbi:
+      - addr:
+          - 127.0.0.10
+          - ::1
+        port: 7777
+
+parameter:
+
+max:
+
+time:

--- a/examples/Test_https_domain_alias-msaf.yaml
+++ b/examples/Test_https_domain_alias-msaf.yaml
@@ -1,0 +1,28 @@
+logger:
+  level: debug
+  domain: msaf
+
+msaf:
+    open5gsIntegration: false
+    sbi:
+      - addr: 0.0.0.0
+        port: 7778
+    applicationServers:
+      - canonicalHostname: localhost
+        urlPathPrefixFormat: /m4d/provisioning-session-{provisioningSessionId}/
+        m3Port: 7777
+    certificate: Certificates.json
+    contentHostingConfiguration: ContentHostingConfiguration_Big-Buck-Bunny_pull-ingest_domain-name_http_and_https.json
+
+nrf:
+    sbi:
+      - addr:
+          - 127.0.0.10
+          - ::1
+        port: 7777
+
+parameter:
+
+max:
+
+time:

--- a/src/5gmsaf/application-server-context.c
+++ b/src/5gmsaf/application-server-context.c
@@ -148,8 +148,10 @@ void next_action_for_application_server(msaf_application_server_state_node_t *as
     ogs_assert(as_state);
 
     if (as_state->current_certificates == NULL)  {
+	ogs_debug("M3 client: Sending GET method to Application Server [%s] to request the list of known certificates", as_state->application_server->canonicalHostname);
         m3_client_as_state_requests(as_state, NULL, NULL, (char *)OGS_SBI_HTTP_METHOD_GET, "certificates");
     } else if (as_state->current_content_hosting_configurations == NULL) {
+	ogs_debug("M3 client: Sending GET method to Application Server [%s] to request the list of known content-hosting-configurations", as_state->application_server->canonicalHostname);
         m3_client_as_state_requests(as_state, NULL, NULL, (char *)OGS_SBI_HTTP_METHOD_GET, "content-hosting-configurations");
     } else if (ogs_list_first(&as_state->upload_certificates) != NULL) {
         const char *upload_cert_filename;
@@ -255,12 +257,11 @@ void next_action_for_application_server(msaf_application_server_state_node_t *as
         purge_resource_id_node_t *purge_chc = ogs_list_first(&as_state->purge_content_hosting_cache);
 	char *component = ogs_msprintf("content-hosting-configurations/%s/purge", purge_chc->state);
 	if(purge_chc->purge_regex) {
-            ogs_debug("M3 client: Sending cache purge operation for resource [%s] to the Application Server", purge_chc->state);
-	    m3_client_as_state_requests(as_state, "application/x-www-form-urlencoded", purge_chc->purge_regex, (char *)OGS_SBI_HTTP_METHOD_POST, component);
+            ogs_debug("M3 client: Sending cache purge operation for resource [%s] using filter [%s] to the Application Server", purge_chc->state, purge_chc->purge_regex);
 	} else {
             ogs_debug("M3 client: Sending Purge operation for cache [%s] to the Application Server", purge_chc->state);
-            m3_client_as_state_requests(as_state, NULL, NULL, (char *)OGS_SBI_HTTP_METHOD_POST, component);
 	}
+        m3_client_as_state_requests(as_state, "application/x-www-form-urlencoded", purge_chc->purge_regex, (char *)OGS_SBI_HTTP_METHOD_POST, component);
 	ogs_free(component);
     }
 }


### PR DESCRIPTION
This PR adds some more example files and improves the logging of M3 requests.

There are new ContentHostingConfiguration JSON files which include a `domainNameAlias` of `media.example.com` for testing those parts of the Application Function which should prefer to use `domainNameAlias` over `canonicalDomainName` (or vice-versa).

There are some testing `msaf.yaml` Application Function YAML configuration files which turn on debug output and reference different ContentHostingConfiguration JSON files. This will make documenting test procedures easier and is a start on automating CI testing.

The examples folder README has also been updated to reflect these changes.