### PR TITLE
Updated documentation for solving building error

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,13 @@ git submodule update
 
 To build the 5GMS Application Function from the source:
 
-```bash
+```
 cd ~/rt-5gms-application-function
-meson build
+meson build --prefix=`pwd`/install
 ninja -C build
 ```
+In case of error during building process using `meson`, please check your Java version.
+Error is probably related to fetching `openapi-generator-cli.jar` module, which requires [Java Development Kit](https://www.oracle.com/java/technologies/downloads/) installed and configured on your system.
 
 ## Installing
 
@@ -54,7 +56,7 @@ To install the built Application Function as a system process:
 
 ```bash
 cd ~/rt-5gms-application-function/build
-sudo meson install --no-rebuild
+ninja install
 ```
 
 ## Running


### PR DESCRIPTION
Updated readme file, adding the solution to error which occurs while building AF. Testing was provided on virtual machines as well as under the native Linux administration. Script fails to fetch .jar file for which JDK is required. Not every system have JDK installed by default.