### PR TITLE
Fix for lack of relative filenames in msaf.yaml and documentation improvements for release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This AF uses the [Open5GS](https://open5gs.org/) framework to implement the netw
 ## Install dependencies
 
 ```bash
-sudo apt install git python3-pip python3-venv python3-setuptools python3-wheel ninja-build build-essential flex bison git libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev meson curl
+sudo apt install git python3-pip python3-venv python3-setuptools python3-wheel ninja-build build-essential flex bison git libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev meson curl wget default-jdk
 python3 -m pip install build
 ```
 
@@ -40,6 +40,8 @@ git submodule update
 
 ## Build the 5GMS Application Function
 
+The build process requires a working Internet connection as the API files are retrieved at build time.
+
 To build the 5GMS Application Function from the source:
 
 ```bash
@@ -47,6 +49,8 @@ cd ~/rt-5gms-application-function
 meson build
 ninja -C build
 ```
+
+**Note:** Errors during the `meson build` command are often caused by missing dependancies or a network issue while trying to retrieve the API files and `openapi-generator` JAR file. See the `~/rt-5gms-application-function/build/meson-logs/meson-log.txt` log file for the errors in greater detail. Search for `generator-5gmsaf` to find the start of the API fetch sequence.
 
 ## Installing
 
@@ -76,119 +80,9 @@ specify an alternative configuration file. For example:
 
 The source example configuration file can be found in `~/rt-5gms-application-function/src/5gmsaf/msaf.yaml`.
 
-## Testing with the example configuration
+## Testing
 
-### Testing the M5 interface
-
-If you started the 5GMS Application Function with the default configuration (`msaf.yaml`), you can test it by retrieving
-`http://localhost:7778/3gpp-m5/v2/service-access-information/{provisioning-session-id}`. Where `{provisioning-session-id}`
-is the provisioning session ID reported by the 5GMS Application Function in its log.
-
-For example:
-
-```bash
-curl -v http://localhost:7778/3gpp-m5/v2/service-access-information/0f9e5e28-a3c5-41ed-8dd9-432c02738477
-```
-
-...would receive a response like:
-
-```
-< HTTP/1.1 200 OK
-< Date: Fri, 28 Oct 2022 16:26:09 GMT
-< Connection: close
-< Content-Type: application/json
-< Content-Length: 278
-< 
-{
-	"provisioningSessionId":	"0f9e5e28-a3c5-41ed-8dd9-432c02738477",
-	"provisioningSessionType":	"DOWNLINK",
-	"streamingAccess":	{
-		"mediaPlayerEntry":	"http://localhost/m4d/provisioning-session-0f9e5e28-a3c5-41ed-8dd9-432c02738477/BigBuckBunny_4s_onDemand_2014_05_09.mpd"
-	}
-}
-```
-
-The not found response can be tested using a different provisioningSessionId string to the value in the
-provisioningSessionId key in the configuration YAML file. For example:
-
-```bash
-curl -v http://localhost:7778/3gpp-m5/v2/service-access-information/does_not_exist
-```
-
-...which would receive a response like:
-
-```
-< HTTP/1.1 404 Not Found
-< Date: Fri, 28 Oct 2022 16:26:28 GMT
-< Connection: close
-< Content-Type: application/problem+json
-< Content-Length: 218
-< 
-{
-	"type":	"/3gpp-m5/v2",
-	"title":	"Service Access Information not found",
-	"status":	404,
-	"detail":	"Service Access Information does_not_exist not found.",
-	"instance":	"/service-access-information/does_not_exist"
-}
-```
-
-### Testing the M3 interface
-
-To see the M3 operations taking place you will need to increase logging level to `debug` by setting the `logging.level` property in the `msaf.yaml` file. For example:
-
-```yaml
-logging:
-    level: debug
-    domain: msaf
-```
-
-With the logging at `debug` level, the Application Function will report significant communications with the Application Server in
-its log output. For example:
-
-```
-Open5GS daemon v2.4.11-31-gf1c0b6d+
-02/03 13:17:08.426: [app] INFO: Configuration: '/usr/local/etc/open5gs/msaf.yaml' (../subprojects/open5gs/lib/app/ogs-init.c:126)
-02/03 13:17:08.427: [sbi] INFO: mhd_server() [0.0.0.0]:7778 (../subprojects/open5gs/lib/sbi/mhd-server.c:279)
-02/03 13:17:08.427: [msaf] DEBUG: msaf_state_initial(): INIT (../src/5gmsaf/msaf-sm.c:20)
-02/03 13:17:08.427: [msaf] DEBUG: msaf_state_functional(): ENTRY (../src/5gmsaf/msaf-sm.c:47)
-02/03 13:17:08.427: [msaf] INFO: [0f9e57de-a3c5-41ed-8dd9-432c02738477] MSAF Running (../src/5gmsaf/msaf-sm.c:53)
-02/03 13:17:08.427: [msaf] DEBUG: BigBuckBunny_4s_onDemand_2014_05_09.mpd matches the regular expression (../src/5gmsaf/provisioning-session.c:592)
-02/03 13:17:08.427: [msaf] DEBUG: Distribution URL: http://msaf01.example.net/m4d/ (../src/5gmsaf/provisioning-session.c:540)
-02/03 13:17:08.427: [app] INFO: 5GMSAF initialize...done (../src/5gmsaf/app.c:24)
-02/03 13:17:08.427: [msaf] INFO: Provisioning session = 0f9e5e28-a3c5-41ed-8dd9-432c02738477 (../src/5gmsaf/msaf-sm.c:57)
-02/03 13:17:08.473: [msaf] DEBUG: msaf_state_functional(): OGS_EVENT_NAME_SBI_CLIENT (../src/5gmsaf/msaf-sm.c:47)
-02/03 13:17:08.473: [msaf] DEBUG: [certificates] Method [GET] with Response [200] received (../src/5gmsaf/msaf-sm.c:1111)
-02/03 13:17:08.473: [msaf] DEBUG: Adding certificate [8578424e-9cae-41ed-9e7a-f3a3ae58dd9b:dn01] to Current certificates (../src/5gmsaf/msaf-sm.c:1139)
-02/03 13:17:08.473: [msaf] DEBUG: Adding certificate [30d46048-a3c4-41ed-86b2-7b1b5377721f:dn01] to Current certificates (../src/5gmsaf/msaf-sm.c:1139)
-02/03 13:17:08.473: [msaf] DEBUG: Adding certificate [bf5fc424-a3c4-41ed-be95-b7864fdc6a53:dn01] to Current certificates (../src/5gmsaf/msaf-sm.c:1139)
-02/03 13:17:08.474: [msaf] DEBUG: msaf_state_functional(): OGS_EVENT_NAME_SBI_CLIENT (../src/5gmsaf/msaf-sm.c:47)
-02/03 13:17:08.474: [msaf] DEBUG: [content-hosting-configurations] Method [GET] with Response [200] for Content Hosting Configuration operation [(null)] (../src/5gmsaf/msaf-sm.c:888)
-02/03 13:17:08.474: [msaf] DEBUG: Adding [8578424e-9cae-41ed-9e7a-f3a3ae58dd9b] to the current Content Hosting Configuration list (../src/5gmsaf/msaf-sm.c:913)
-02/03 13:17:08.474: [msaf] DEBUG: Adding [30d46048-a3c4-41ed-86b2-7b1b5377721f] to the current Content Hosting Configuration list (../src/5gmsaf/msaf-sm.c:913)
-02/03 13:17:08.474: [msaf] DEBUG: Adding [bf5fc424-a3c4-41ed-be95-b7864fdc6a53] to the current Content Hosting Configuration list (../src/5gmsaf/msaf-sm.c:913)
-02/03 13:17:08.474: [msaf] DEBUG: M3 client: Sending POST method to Application Server [localhost] for Content Hosting Configuration:  [0f9e5e28-a3c5-41ed-8dd9-432c02738477] (../src/5gmsaf/application-server-context.c:233)
-02/03 13:17:08.517: [msaf] DEBUG: msaf_state_functional(): OGS_EVENT_NAME_SBI_CLIENT (../src/5gmsaf/msaf-sm.c:47)
-02/03 13:17:08.517: [msaf] DEBUG: [content-hosting-configurations] Method [POST] with Response [201] recieved for Content Hosting Configuration [0f9e5e28-a3c5-41ed-8dd9-432c02738477] (../src/5gmsaf/msaf-sm.c:736)
-02/03 13:17:08.517: [msaf] DEBUG: Removing 0f9e5e28-a3c5-41ed-8dd9-432c02738477 from upload_content_hosting_configurations (../src/5gmsaf/msaf-sm.c:745)
-02/03 13:17:08.517: [msaf] DEBUG: Adding 0f9e5e28-a3c5-41ed-8dd9-432c02738477 to current_content_hosting_configurations (../src/5gmsaf/msaf-sm.c:747)
-```
-
-The above log shows the Application Function learning that the Application Server already knows about 3 certificates (`8578424e-9cae-41ed-9e7a-f3a3ae58dd9b:dn01`, `30d46048-a3c4-41ed-86b2-7b1b5377721f:dn01` and `bf5fc424-a3c4-41ed-be95-b7864fdc6a53:dn01`), it then learns that it has 3 content-hosting-configurations (`8578424e-9cae-41ed-9e7a-f3a3ae58dd9b`, `30d46048-a3c4-41ed-86b2-7b1b5377721f` and `bf5fc424-a3c4-41ed-be95-b7864fdc6a53`), and finally it uploads the new content hosting configuration to the AS (`0f9e5e28-a3c5-41ed-8dd9-432c02738477`).
-
-The log of the Application Server can also be checked for communications with the AF:
-
-```
-INFO:rt-5gms-as:Getting list of certificates...
-[2023-02-03 13:17:08 +0000] [28235] [INFO] 127.0.0.1:49538 - - [03/Feb/2023:13:17:08 +0000] "GET /3gpp-m3/v1/certificates 2" 200 208 "-" "-"
-INFO:rt-5gms-as:Getting list of content hosting configurations...
-[2023-02-03 13:17:08 +0000] [28235] [INFO] 127.0.0.1:49538 - - [03/Feb/2023:13:17:08 +0000] "GET /3gpp-m3/v1/content-hosting-configurations 2" 200 247 "-" "-"
-INFO:rt-5gms-as:Adding content hosting configuration 0f9e5e28-a3c5-41ed-8dd9-432c02738477...
-INFO:rt-5gms-as:Reloading proxy daemon...
-[2023-02-03 13:17:08 +0000] [28235] [INFO] 127.0.0.1:49546 - - [03/Feb/2023:13:17:08 +0000] "POST /3gpp-m3/v1/content-hosting-configurations/0f9e5e28-a3c5-41ed-8dd9-432c02738477 2" 201 0 "-" "-"
-```
-
-These log lines from the Application Server can be seen to match the requests in the Application Function log.
+See the section on [Testing](https://github.com/5G-MAG/rt-5gms-application-function/wiki/Developing-and-Contributing#testing) in the wiki.
 
 ## Development
 

--- a/src/5gmsaf/context.c
+++ b/src/5gmsaf/context.c
@@ -133,9 +133,9 @@ int msaf_context_parse_config(void)
                         self->config.open5gsIntegration_flag = 1;
                     }
                 } else if (!strcmp(msaf_key, "certificate")) {
-                    self->config.certificate = ogs_strdup(ogs_yaml_iter_value(&msaf_iter));
+                    self->config.certificate = rebase_path(ogs_app()->file, ogs_yaml_iter_value(&msaf_iter));
                 } else if (!strcmp(msaf_key, "contentHostingConfiguration")) {
-                    self->config.contentHostingConfiguration = ogs_strdup(ogs_yaml_iter_value(&msaf_iter));
+                    self->config.contentHostingConfiguration = rebase_path(ogs_app()->file, ogs_yaml_iter_value(&msaf_iter));
                 } else if (!strcmp(msaf_key, "applicationServers")) {
                     ogs_yaml_iter_t as_iter, as_array;
                     ogs_yaml_iter_recurse(&msaf_iter, &as_array);
@@ -644,17 +644,7 @@ safe_ogs_free(void *memory)
 ogs_hash_t *
 msaf_context_content_hosting_configuration_file_map(char *provisioning_session_id)
 {
-    char *chc_file = NULL;
-    char *chc_file_name = NULL;
-    char *path = NULL;
-    path = get_path(self->config.contentHostingConfiguration);
-    ogs_assert(path);
-    chc_file = basename(self->config.contentHostingConfiguration);
-    ogs_assert(chc_file);
-    chc_file_name = ogs_msprintf("%s/%s", path, chc_file);
-    ogs_assert(chc_file_name);
-    ogs_hash_set(self->content_hosting_configuration_file_map, chc_file_name, OGS_HASH_KEY_STRING, ogs_strdup(provisioning_session_id));
-    ogs_free(path);
+    ogs_hash_set(self->content_hosting_configuration_file_map, ogs_strdup(self->config.contentHostingConfiguration), OGS_HASH_KEY_STRING, ogs_strdup(provisioning_session_id));
     return self->content_hosting_configuration_file_map;
 }
 

--- a/src/5gmsaf/provisioning-session.c
+++ b/src/5gmsaf/provisioning-session.c
@@ -290,7 +290,6 @@ msaf_provisioning_session_find_by_provisioningSessionId(const char *provisioning
 ogs_hash_t *
 msaf_certificate_map(void)
 {
-    char *path = NULL;
     cJSON *entry;
     ogs_hash_t *certificate_map = ogs_hash_make();
     char *certificate = read_file(msaf_self()->config.certificate);
@@ -301,25 +300,15 @@ msaf_certificate_map(void)
     if (!cert) {
         ogs_error("The certificates JSON file [%s] does not parse as JSON.", msaf_self()->config.certificate);
     }
-    path = get_path(msaf_self()->config.certificate);
-    if (!path) {
-        ogs_error("The Application Function could not get path of the certificate file.");
-    }
-    ogs_assert(path);
     cJSON_ArrayForEach(entry, cert) {
         char *abs_path;
         if (!entry->valuestring) {
             ogs_error("Certificates JSON file configuration parameter has not been set");
-
-        } else
-        if (entry->valuestring[0] != '/') {
-            abs_path = ogs_msprintf("%s/%s", path, entry->valuestring);
-        } else {
-            abs_path = ogs_strdup(entry->valuestring);
+	    continue;
         }
+	abs_path = rebase_path(msaf_self()->config.certificate, entry->valuestring);
         ogs_hash_set(certificate_map, ogs_strdup(entry->string), OGS_HASH_KEY_STRING, abs_path);
     }
-    ogs_free(path);
     cJSON_Delete(entry);
     cJSON_Delete(cert);
     free(certificate);

--- a/src/5gmsaf/utilities.c
+++ b/src/5gmsaf/utilities.c
@@ -54,6 +54,21 @@ char *get_path(const char *file)
     return file_dir;
 }
 
+char *rebase_path(const char *base, const char *file)
+{
+    ogs_debug("rebase_path(\"%s\", \"%s\")", base, file);
+    if (file[0] != '/') {
+        /* relative path - prefix with the directory of the base filename */
+        char *base_path, *path;
+        base_path = get_path(base);
+        path = ogs_msprintf("%s/%s", base_path, file);
+        ogs_free(base_path);
+        return path;
+    }
+    /* absolute path - return a copy */
+    return ogs_strdup(file);
+}
+
 long int ascii_to_long(const char *str)
 {
     char *endp = NULL;
@@ -67,3 +82,5 @@ long int ascii_to_long(const char *str)
     return ret;
 }
 
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/5gmsaf/utilities.h
+++ b/src/5gmsaf/utilities.h
@@ -22,6 +22,7 @@ extern "C" {
 
 extern char *read_file(const char *filename);
 extern char *get_path(const char *file);
+extern char *rebase_path(const char *base, const char *file);
 extern long int ascii_to_long(const char *str);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR fixes the issue of relative filenames in the `msaf.yaml` configuration file not being relative to the configuration file itself.

This also introduces a note about the requirement for an Internet connection during build and diagnosing failures to fetch the API or openapi-generator JAR file during building. This supersedes PR #43.

I think this deals with the last issues found by myself while documenting the tests, and by @stepski011 and others while testing.