### PR TITLE
Fix: TS 26.512 v17.4.0 APIs rollback for v1.2.x branch

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@
 # Meson module fs and its functions like fs.hash_file require atleast meson 0.59.0 
 
 project('rt-5gms-application-function', 'c',
-    version : '1.2.0',
+    version : '1.2.1',
     license : '5G-MAG Public',
     meson_version : '>= 0.59.0',
     default_options : [

--- a/src/5gmsaf/meson.build
+++ b/src/5gmsaf/meson.build
@@ -189,7 +189,7 @@ libmsaf_gen_sources = '''
 '''.split()
 
 gen_5gmsaf_openapi = find_program('sh')
-openapi_gen_result = run_command([gen_5gmsaf_openapi,'-c','$MESON_SOURCE_ROOT/$MESON_SUBDIR/generator-5gmsaf', '-b', 'REL-'+fiveg_api_release], check: true, capture: false)
+openapi_gen_result = run_command([gen_5gmsaf_openapi,'-c', '$MESON_SOURCE_ROOT/$MESON_SUBDIR/generator-5gmsaf -b TSG98-Rel'+fiveg_api_release], check: true, capture: false)
 
 json_file = files(['ContentProtocolsDiscovery_body.json'])
 file_content = ''


### PR DESCRIPTION
The recent 3GPP changes to introduce the v17.4.0 API changes to the 5G_APIs repository are breaking the v1.2.0 release of the 5GMS Application Function.

This is a quick fix that forces the version of the 5G_APIs back to the TS 26.512 v17.3.0 release API files by selecting the `TSG98-Rel17` release tag for the 5G_APIs instead of the 'REL-17' branch.