### PR TITLE
Bug Fixes: Memory leak in AF and fix for m1-session del-stream matching

### DIFF
--- a/src/5gmsaf/msaf-m5-sm.c
+++ b/src/5gmsaf/msaf-m5-sm.c
@@ -95,6 +95,7 @@ void msaf_m5_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                             err = ogs_msprintf("Provisioning Session [%s] not found.", message->h.resource.component[1]);
                             ogs_error("%s", err);
                             ogs_assert(true == nf_server_send_error(stream, 404, 1, message, "Provisioning Session not found.", err, NULL, m5_serviceaccessinformation_api, app_meta));
+                            ogs_free(err);
                         } else if (msaf_provisioning_session->serviceAccessInformation) {
                             service_access_information = msaf_context_retrieve_service_access_information(message->h.resource.component[1]);
                             if (service_access_information != NULL) {
@@ -102,7 +103,7 @@ void msaf_m5_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                 char *text;
                                 text = cJSON_Print(service_access_information);
                                 response = nf_server_new_response(NULL, "application/json",  msaf_provisioning_session->serviceAccessInformationCreated, msaf_provisioning_session->serviceAccessInformationHash, msaf_self()->config.server_response_cache_control->m5_service_access_information_response_max_age, NULL, m5_serviceaccessinformation_api, app_meta);
-                                nf_server_populate_response(response, strlen(text), text, 201);
+                                nf_server_populate_response(response, strlen(text), text, 200);
                                 ogs_assert(response);
                                 ogs_assert(true == ogs_sbi_server_send_response(stream, response));
                                 cJSON_Delete(service_access_information);

--- a/tools/python3/lib/rt_m1_client/session.py
+++ b/tools/python3/lib/rt_m1_client/session.py
@@ -198,7 +198,9 @@ class M1Session:
             if ps is None or ps['content-hosting-configuration'] is None:
                 continue
             if ps['content-hosting-configuration']['contenthostingconfiguration']['ingestConfiguration']['baseURL'] == ingesturl:
-                if (entrypoint is None and 'entryPointPath' not in ps['content-hosting-configuration']['contenthostingconfiguration']) or (entrypoint is not None and 'entryPointPath' in ps['content-hosting-configuration']['contenthostingconfiguration'] and ps['content-hosting-configuration']['contenthostingconfiguration']['entryPointPath'] == entrypoint):
+                entry_points = [dc['entryPoint'] for dc in ps['content-hosting-configuration']['contenthostingconfiguration']['distributionConfigurations'] if 'entryPoint' in dc]
+                entry_point_paths = [e['relativePath'] for e in entry_points]
+                if (entrypoint is None and len(entry_point_paths) == 0) or (entrypoint is not None and entrypoint in entry_point_paths):
                     ret = ps_id
                     break
         return ret


### PR DESCRIPTION
This is a fix for a memory leak when the M5 interface reports that the provisioning session id cannot be found. The error text was being leaked every time this error was generated.

Also fixes a bug introduced in the M5 interface where the wrong HTTP status code was being returned with a service-access-information request response.

This PR also includes some fixes for the `m1-session` tool for matching provisioning sessions by the ingest URL and one entry point relative path, and improvements to the display of ContentHostingConfiguration information.
