### PR TITLE
Uplift to TS 26.512 V17.6.0 and Release 17 version of Open5GS

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,3 @@
 option('latest_apis', type: 'boolean', value: false)
-option('fiveg_api_approval', type: 'string', value: '99')
+option('fiveg_api_approval', type: 'string', value: '100')
 option('fiveg_api_release', type: 'string', value: '17')

--- a/src/5gmsaf/.gitignore
+++ b/src/5gmsaf/.gitignore
@@ -1,2 +1,3 @@
 openapi
 config.yaml
+.openapi.deps

--- a/src/5gmsaf/application-server-context.c
+++ b/src/5gmsaf/application-server-context.c
@@ -350,6 +350,7 @@ static ogs_sbi_client_t *msaf_m3_client_init(const char *hostname, int port)
     int rv;
     ogs_sbi_client_t *client = NULL;
     ogs_sockaddr_t *addr = NULL;
+    OpenAPI_uri_scheme_e scheme = OpenAPI_uri_scheme_http;
 
     rv = ogs_getaddrinfo(&addr, AF_UNSPEC, hostname, port, 0);
     if (rv != OGS_OK) {
@@ -360,7 +361,7 @@ static ogs_sbi_client_t *msaf_m3_client_init(const char *hostname, int port)
     if (addr == NULL)
         ogs_error("Could not get the address of the Application Server");
 
-    client = ogs_sbi_client_add(addr);
+    client = ogs_sbi_client_add(scheme, addr);
     ogs_assert(client);
 
     ogs_freeaddrinfo(addr);

--- a/src/5gmsaf/application-server-context.h
+++ b/src/5gmsaf/application-server-context.h
@@ -23,6 +23,7 @@ typedef struct msaf_application_server_node_s {
     char *canonicalHostname;
     char *urlPathPrefixFormat;
     int   m3Port;
+    char *m3Host;
 } msaf_application_server_node_t;
 
 typedef struct msaf_application_server_state_node_s {
@@ -72,7 +73,7 @@ typedef struct purge_resource_id_node_s {
  */
 extern int msaf_application_server_state_set(msaf_application_server_state_node_t *as_state, msaf_provisioning_session_t *provisioning_session);
 extern void msaf_application_server_state_log(ogs_list_t *list, const char* list_name);
-extern msaf_application_server_node_t *msaf_application_server_add(char *canonical_hostname, char *url_path_prefix_format, int m3_port);
+extern msaf_application_server_node_t *msaf_application_server_add(char *canonical_hostname, char *url_path_prefix_format, int m3_port, char *m3_host);
 extern void msaf_application_server_remove_all(void);
 extern void msaf_application_server_print_all(void);
 extern void next_action_for_application_server(msaf_application_server_state_node_t *as_state);

--- a/src/5gmsaf/certmgr.h
+++ b/src/5gmsaf/certmgr.h
@@ -29,11 +29,16 @@ typedef struct msaf_certificate_s {
 } msaf_certificate_t;
 
 typedef struct msaf_assigned_certificate_s {
-    ogs_lnode_t       node;	
+    ogs_lnode_t node;
     char *certificate_id;
 } msaf_assigned_certificate_t;
 
-extern msaf_certificate_t *server_cert_new(const char *operation, const char *operation_params);
+typedef struct fqdn_list_node_s {
+    ogs_lnode_t node;
+    char *fqdn;
+} fqdn_list_node_t;
+
+extern msaf_certificate_t *server_cert_new(const char *operation, const char *common_name, ogs_list_t *extra_fqdns);
 extern int server_cert_set(const char *cert_id, const char *cert);
 extern msaf_certificate_t *server_cert_retrieve(const char *certid);
 extern msaf_certificate_t *server_cert_get_servercert(const char *certid);
@@ -44,5 +49,8 @@ extern void msaf_certificate_free(msaf_certificate_t *cert);
 #ifdef __cplusplus
 }
 #endif
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
 
 #endif /* MSAF_CERT_MGR_H */

--- a/src/5gmsaf/context.c
+++ b/src/5gmsaf/context.c
@@ -383,9 +383,10 @@ int msaf_context_parse_config(void)
                                     if (addr && ogs_app()->parameter.no_ipv4 == 0)
                                         ogs_sbi_server_set_advertise(
                                                 server, AF_INET, addr);
-                                
+                                /*
                                     if (key) server->tls.key = key;
                                     if (pem) server->tls.pem = pem;
+                                */
                                 }
 
                                 if (!strcmp(msaf_key, "sbi")) {
@@ -445,9 +446,10 @@ int msaf_context_parse_config(void)
                                     if (addr && ogs_app()->parameter.no_ipv6 == 0)
                                         ogs_sbi_server_set_advertise(
                                                 server, AF_INET6, addr);
-
+                                    /*
                                     if (key) server->tls.key = key;
                                     if (pem) server->tls.pem = pem;
+                                    */
                                     if (!strcmp(msaf_key, "sbi")) {
                                         ogs_assert(OGS_OK == ogs_copyaddrinfo(&self->config.sbi_server_sockaddr_v6, server->node.addr));
                                         if(!self->config.m1_server_sockaddr_v6){

--- a/src/5gmsaf/context.c
+++ b/src/5gmsaf/context.c
@@ -151,6 +151,11 @@ int msaf_context_parse_config(void)
                     self->config.certificateManager = msaf_strdup(ogs_yaml_iter_value(&msaf_iter));
                 } else if (!strcmp(msaf_key, "applicationServers")) {
                     ogs_yaml_iter_t as_iter, as_array;
+                    char *canonical_hostname = NULL;
+                    char *url_path_prefix_format = NULL;
+                    int m3_port = 80;
+                    char *m3_host = NULL;
+
                     ogs_yaml_iter_recurse(&msaf_iter, &as_array);
                     if (ogs_yaml_iter_type(&as_array) == YAML_MAPPING_NODE) {
                         memcpy(&as_iter, &as_array, sizeof(ogs_yaml_iter_t));
@@ -160,11 +165,9 @@ int msaf_context_parse_config(void)
                         ogs_yaml_iter_recurse(&as_array, &as_iter);
                     } else if (ogs_yaml_iter_type(&as_array) == YAML_SCALAR_NODE) {
                         break;
-                    } else
+                    } else {
                         ogs_assert_if_reached();
-                    char *canonical_hostname = NULL;
-                    char *url_path_prefix_format = NULL;
-                    int m3_port = 80;
+                    }
                     while (ogs_yaml_iter_next(&as_iter)) {
                         const char *as_key = ogs_yaml_iter_key(&as_iter);
                         ogs_assert(as_key);
@@ -174,9 +177,11 @@ int msaf_context_parse_config(void)
                             url_path_prefix_format = msaf_strdup(ogs_yaml_iter_value(&as_iter));
                         } else if (!strcmp(as_key, "m3Port")) {
                             m3_port = ascii_to_long(ogs_yaml_iter_value(&as_iter));
+                        } else if (!strcmp(as_key, "m3Host")) {
+                            m3_host = msaf_strdup(ogs_yaml_iter_value(&as_iter));
                         }
                     }
-                    msaf_application_server_add(canonical_hostname, url_path_prefix_format, m3_port);
+                    msaf_application_server_add(canonical_hostname, url_path_prefix_format, m3_port, m3_host);
                 } else if (!strcmp(msaf_key, "serverResponseCacheControl")) {
                     ogs_yaml_iter_t cc_iter, cc_array;
                     ogs_yaml_iter_recurse(&msaf_iter, &cc_array);

--- a/src/5gmsaf/context.h
+++ b/src/5gmsaf/context.h
@@ -42,20 +42,30 @@ extern int __msaf_log_domain;
 #undef OGS_LOG_DOMAIN
 #define OGS_LOG_DOMAIN __msaf_log_domain
 
+typedef struct msaf_configuration_server_s {
+    ogs_sockaddr_t *ipv4;
+    ogs_sockaddr_t *ipv6;
+    ogs_sbi_server_t *server_v4;
+    ogs_sbi_server_t *server_v6;
+} msaf_configuration_server_t;
+
+typedef enum msaf_configuration_server_ifc_e {
+    MSAF_SVR_SBI = 0,
+    MSAF_SVR_M1,
+    MSAF_SVR_M5,
+    MSAF_SVR_MSAF,
+
+    MSAF_SVR_NUM_IFCS
+} msaf_configuration_server_ifc_t;
+
 typedef struct msaf_configuration_s {
     int open5gsIntegration_flag;
     ogs_list_t applicationServers_list;
     ogs_list_t server_addr_list; // Nodes for this list are of type msaf_sbi_addr_t *
     char *certificateManager;
+
+    msaf_configuration_server_t servers[MSAF_SVR_NUM_IFCS];
     
-    ogs_sockaddr_t *m1_server_sockaddr;
-    ogs_sockaddr_t *m5_server_sockaddr;
-    ogs_sockaddr_t *maf_mgmt_server_sockaddr;
-    ogs_sockaddr_t *sbi_server_sockaddr;
-    ogs_sockaddr_t *sbi_server_sockaddr_v6;
-    ogs_sockaddr_t *m1_server_sockaddr_v6;
-    ogs_sockaddr_t *m5_server_sockaddr_v6;
-    ogs_sockaddr_t *maf_mgmt_server_sockaddr_v6;
     msaf_server_response_cache_control_t *server_response_cache_control;
     int  number_of_application_servers;
 } msaf_configuration_t;

--- a/src/5gmsaf/generator-5gmsaf
+++ b/src/5gmsaf/generator-5gmsaf
@@ -32,7 +32,7 @@ default_branch='REL-17'
 default_apis="TS26512_M1_ProvisioningSessions TS26512_M1_ContentHostingProvisioning TS26512_M1_ServerCertificatesProvisioning TS26512_M1_ContentProtocolsDiscovery M3_ContentHostingProvisioning M3_ServerCertificatesProvisioning TS26512_M5_ServiceAccessInformation Maf_Management"
 
 # Parse command line arguments
-ARGS=`getopt -n "$scriptname" -o 'a:b:h' -l 'api:,branch:,help' -s sh -- "$@"`
+ARGS=`getopt -n "$scriptname" -o 'a:b:hM:' -l 'api:,branch:,help,model-deps:' -s sh -- "$@"`
 
 if [ $? -ne 0 ]; then
     print_syntax >&2
@@ -40,7 +40,7 @@ if [ $? -ne 0 ]; then
 fi
 
 print_syntax() {
-    echo "Syntax: $scriptname [-h] [-b <release-branch>] [-a <API-name>]"
+    echo "Syntax: $scriptname [-h] [-b <release-branch>] [-a <API-name>] [-M <model-deps-file>"
 }
 
 print_help() {
@@ -55,12 +55,15 @@ EOF
     cat <<EOF
 
 Options:
-  -h         --help           Show this help message and exit.
-  -a API     --api API        The OpenAPI interface to generate the bindings
-			      from (e.g. TS26512_M1_ContentHostingProvisioning).
-			      [default: $default_apis]
-  -b BRANCH  --branch BRANCH  Use the given branch of the 5G_APIs repository.
-                              [default: $default_branch]
+  -h         --help                Show this help message and exit.
+  -a API     --api API             The OpenAPI interface to generate the
+                                   bindings from (e.g.
+                                   TS26512_M1_ContentHostingProvisioning).
+			           [default: $default_apis]
+  -b BRANCH  --branch BRANCH       Use the given branch of the 5G_APIs
+                                   repository. [default: $default_branch]
+  -M DEPFILE --model-deps DEPFILE  File to store the list of generated model
+                                   source files.
 EOF
 }
 
@@ -69,6 +72,7 @@ unset ARGS
 
 APIS="$default_apis"
 BRANCH="$default_branch"
+MODEL_DEPS=""
 
 while true; do
     case "$1" in
@@ -85,6 +89,11 @@ while true; do
     -h|--help)
 	print_help
 	exit 0
+	;;
+    -M|--model-deps)
+	MODEL_DEPS="$2"
+	shift 2
+	continue
 	;;
     --)
 	shift
@@ -125,6 +134,18 @@ fi
 "$scriptdir/../../subprojects/rt-common-shared/5gms/scripts/generate_openapi" -a "${APIS}" -b "${BRANCH}" -c "$scriptdir/config.yaml" -l c -d "$scriptdir/openapi" -g 6.4.0 -y "$scriptdir/fix_openapi_yaml.py"
 
 cp "$scriptdir/set.h" "$scriptdir/openapi/model"
+
+# Delete any model file already in the Open5GS SBI library to avoid clashes
+for f in "$scriptdir/openapi/model"/*.[ch]; do
+    b=`basename "$f"`
+    if [ -e "$scriptdir/../../subprojects/open5gs/lib/sbi/openapi/model/$b" ]; then
+	rm "$f"
+    fi
+done
+
+if [ -n "$MODEL_DEPS" ]; then
+    (cd "$scriptdir"; echo openapi/model/*.[ch] > "$MODEL_DEPS")
+fi
 
 exit 0
 

--- a/src/5gmsaf/generator-5gmsaf
+++ b/src/5gmsaf/generator-5gmsaf
@@ -106,7 +106,7 @@ fi
 
 # Get the absolute path to the destination directory
 destdir=`realpath -m "$scriptdir/openapi"`
-openapi_gen_dir=`realpath "$scriptdir/../../subprojects/open5gs/lib/sbi/support/20210629/openapi-generator"`
+openapi_gen_dir=`realpath "$scriptdir/../../subprojects/open5gs/lib/sbi/support/r17-20230301-openapitools-6.4.0/openapi-generator"`
 
 sed "s@^templateDir:.*@templateDir: \"${openapi_gen_dir}/templates\"@" $openapi_gen_dir/config.yaml > $scriptdir/config.yaml
 cp "${scriptdir}/"*.mustache "${openapi_gen_dir}/templates/"
@@ -122,7 +122,7 @@ if [ ! -d "$scriptdir/openapi" ]; then
     mkdir "$scriptdir/openapi"
 fi
 
-"$scriptdir/../../subprojects/rt-common-shared/5gms/scripts/generate_openapi" -a "${APIS}" -b "${BRANCH}" -c "$scriptdir/config.yaml" -l c -d "$scriptdir/openapi" -g 5.2.0 -y "$scriptdir/fix_openapi_yaml.py"
+"$scriptdir/../../subprojects/rt-common-shared/5gms/scripts/generate_openapi" -a "${APIS}" -b "${BRANCH}" -c "$scriptdir/config.yaml" -l c -d "$scriptdir/openapi" -g 6.4.0 -y "$scriptdir/fix_openapi_yaml.py"
 
 cp "$scriptdir/set.h" "$scriptdir/openapi/model"
 

--- a/src/5gmsaf/init.c
+++ b/src/5gmsaf/init.c
@@ -26,7 +26,7 @@ int msaf_initialize()
     rv = msaf_set_time();
     if(rv != 0) return OGS_ERROR;
 
-    ogs_sbi_context_init();
+    ogs_sbi_context_init(OpenAPI_nf_type_AF);
 
     msaf_context_init();
 

--- a/src/5gmsaf/init.c
+++ b/src/5gmsaf/init.c
@@ -96,17 +96,6 @@ static void msaf_main(void *data)
 
     ogs_fsm_init(&msaf_sm, msaf_state_initial, msaf_state_final, 0);
     
-    /*
-    ogs_fsm_init(&msaf_self()->msaf_fsm.msaf_m1_sm, msaf_m1_state_initial, msaf_m1_state_final, 0);
-    ogs_fsm_init(&msaf_self()->msaf_fsm.msaf_m5_sm, msaf_m5_state_initial, msaf_m5_state_final, 0);
-    if(msaf_self()->config.sbi_server_sockaddr || msaf_self()->config.sbi_server_sockaddr_v6) {
-        ogs_fsm_init(&msaf_self()->msaf_fsm.msaf_sbi_sm, msaf_sbi_state_initial, msaf_sbi_state_final, 0);
-    }
-    if(msaf_self()->config.maf_mgmt_server_sockaddr || msaf_self()->config.maf_mgmt_server_sockaddr_v6) {
-        ogs_fsm_init(&msaf_self()->msaf_fsm.msaf_maf_mgmt_sm, msaf_maf_mgmt_state_initial, msaf_maf_mgmt_state_final, 0);
-    }
-    */
-
     for ( ;; ) {
         ogs_pollset_poll(ogs_app()->pollset,
                 ogs_timer_mgr_next(ogs_app()->timer_mgr));
@@ -128,21 +117,7 @@ static void msaf_main(void *data)
             ogs_assert(e);
 
             ogs_fsm_dispatch(&msaf_sm, e);
-            /*
-            rv = get_server_type_from_event(e);
-            if (rv == MSAF_M1_SERVER) {
-                ogs_fsm_dispatch(&msaf_self()->msaf_fsm.msaf_m1_sm, e);
-            }
-            if (rv == MSAF_M5_SERVER) {
-                ogs_fsm_dispatch(&msaf_self()->msaf_fsm.msaf_m5_sm, e);
-            } 
-            if(rv == MSAF_MAF_MGMT_SERVER) {
-                ogs_fsm_dispatch(&msaf_self()->msaf_fsm.msaf_maf_mgmt_sm, e);
-            }            
-            if (rv == MSAF_SBI_SERVER) {
-                ogs_fsm_dispatch(&msaf_self()->msaf_fsm.msaf_sbi_sm, e);
-            }
-            */
+
             ogs_event_free(e);
         }
     }

--- a/src/5gmsaf/meson.build
+++ b/src/5gmsaf/meson.build
@@ -10,12 +10,14 @@
 libapp_dep = open5gs_project.get_variable('libapp_dep')
 libcrypt_dep = open5gs_project.get_variable('libcrypt_dep')
 libsbi_dep = open5gs_project.get_variable('libsbih1_dep')
+libsbi_openapi_dep = open5gs_project.get_variable('libsbi_openapi_dep')
 open5gs_sysconfdir = open5gs_project.get_variable('open5gs_sysconfdir')
 srcinc = open5gs_project.get_variable('srcinc')
 libdir = open5gs_project.get_variable('libdir')
 python3_exe = open5gs_project.get_variable('python3_exe')
 mkdir_p = open5gs_project.get_variable('mkdir_p')
 install_conf = open5gs_project.get_variable('install_conf')
+sbi_openapi_inc = open5gs_project.get_variable('libsbi_openapi_model_inc')
 
 latest_apis = get_option('latest_apis')
 fiveg_api_approval = get_option('fiveg_api_approval')
@@ -59,146 +61,13 @@ libmsaf_dist_sources = files('''
     init.h
 '''.split())
 
-libmsaf_gen_sources = '''
-    openapi/model/caching_configuration.h
-    openapi/model/caching_configuration.c
-    openapi/model/caching_configuration_caching_directives.h
-    openapi/model/caching_configuration_caching_directives.c
-    openapi/model/m1_media_entry_point.h
-    openapi/model/m1_media_entry_point.c
-    openapi/model/m5_media_entry_point.h
-    openapi/model/m5_media_entry_point.c
-    openapi/model/content_hosting_configuration.h
-    openapi/model/content_hosting_configuration.c
-    openapi/model/distribution_configuration.h
-    openapi/model/distribution_configuration.c
-    openapi/model/distribution_configuration_geo_fencing.h
-    openapi/model/distribution_configuration_geo_fencing.c
-    openapi/model/distribution_configuration_supplementary_distribution_networks_inner.h
-    openapi/model/distribution_configuration_supplementary_distribution_networks_inner.c
-    openapi/model/distribution_configuration_url_signature.h
-    openapi/model/distribution_configuration_url_signature.c
-    openapi/model/distribution_mode.h
-    openapi/model/distribution_mode.c
-    openapi/model/distribution_network_type.h
-    openapi/model/distribution_network_type.c
-    openapi/model/ingest_configuration.h
-    openapi/model/ingest_configuration.c
-    openapi/model/path_rewrite_rule.h
-    openapi/model/path_rewrite_rule.c
-    openapi/model/object.c
-    openapi/model/object.h
-    openapi/model/civic_address.h
-    openapi/model/civic_address.c
-    openapi/model/eas_discovery_template.h
-    openapi/model/eas_discovery_template.c
-    openapi/model/eas_relocation_tolerance.h
-    openapi/model/eas_relocation_tolerance.c
-    openapi/model/ecgi.h
-    openapi/model/ecgi.c
-    openapi/model/edge_processing_eligibility_criteria.h
-    openapi/model/edge_processing_eligibility_criteria.c
-    openapi/model/ellipsoid_arc.h
-    openapi/model/ellipsoid_arc.c
-    openapi/model/ellipsoid_arc_all_of.h
-    openapi/model/ellipsoid_arc_all_of.c
-    openapi/model/gad_shape.h
-    openapi/model/gad_shape.c
-    openapi/model/geographic_area.h
-    openapi/model/geographic_area.c
-    openapi/model/geographical_coordinates.h
-    openapi/model/geographical_coordinates.c
-    openapi/model/global_ran_node_id.h
-    openapi/model/global_ran_node_id.c
-    openapi/model/gnb_id.h
-    openapi/model/gnb_id.c
-    openapi/model/ip_packet_filter_set.h
-    openapi/model/ip_packet_filter_set.c
-    openapi/model/local2d_point_uncertainty_ellipse.h
-    openapi/model/local2d_point_uncertainty_ellipse.c
-    openapi/model/local2d_point_uncertainty_ellipse_all_of.h
-    openapi/model/local2d_point_uncertainty_ellipse_all_of.c
-    openapi/model/local3d_point_uncertainty_ellipsoid.h
-    openapi/model/local3d_point_uncertainty_ellipsoid.c
-    openapi/model/local3d_point_uncertainty_ellipsoid_all_of.h
-    openapi/model/local3d_point_uncertainty_ellipsoid_all_of.c
-    openapi/model/local_origin.h
-    openapi/model/local_origin.c
-    openapi/model/location_area5_g.h
-    openapi/model/location_area5_g.c
-    openapi/model/m5_eas_relocation_requirements.h
-    openapi/model/m5_eas_relocation_requirements.c
-    openapi/model/ncgi.h
-    openapi/model/ncgi.c
-    openapi/model/network_area_info.h
-    openapi/model/network_area_info.c
-    openapi/model/plmn_id.h
-    openapi/model/plmn_id.c
-    openapi/model/point.h
-    openapi/model/point.c
-    openapi/model/point_all_of.h
-    openapi/model/point_all_of.c
-    openapi/model/point_altitude.h
-    openapi/model/point_altitude.c
-    openapi/model/point_altitude_all_of.h
-    openapi/model/point_altitude_all_of.c
-    openapi/model/point_altitude_uncertainty.h
-    openapi/model/point_altitude_uncertainty.c
-    openapi/model/point_altitude_uncertainty_all_of.h
-    openapi/model/point_altitude_uncertainty_all_of.c
-    openapi/model/point_uncertainty_circle.h
-    openapi/model/point_uncertainty_circle.c
-    openapi/model/point_uncertainty_circle_all_of.h
-    openapi/model/point_uncertainty_circle_all_of.c
-    openapi/model/point_uncertainty_ellipse.h
-    openapi/model/point_uncertainty_ellipse.c
-    openapi/model/point_uncertainty_ellipse_all_of.h
-    openapi/model/point_uncertainty_ellipse_all_of.c
-    openapi/model/polygon.h
-    openapi/model/polygon.c
-    openapi/model/polygon_all_of.h
-    openapi/model/polygon_all_of.c
-    openapi/model/provisioning_session_type.h
-    openapi/model/provisioning_session_type.c
-    openapi/model/provisioning_session.h
-    openapi/model/provisioning_session.c
-    openapi/model/relative_cartesian_location.h
-    openapi/model/relative_cartesian_location.c
-    openapi/model/sdf_method.h
-    openapi/model/sdf_method.c
-    openapi/model/service_access_information_resource.h
-    openapi/model/service_access_information_resource.c
-    openapi/model/service_access_information_resource_client_consumption_reporting_configuration.h
-    openapi/model/service_access_information_resource_client_consumption_reporting_configuration.c
-    openapi/model/service_access_information_resource_client_edge_resources_configuration.h
-    openapi/model/service_access_information_resource_client_edge_resources_configuration.c
-    openapi/model/service_access_information_resource_client_metrics_reporting_configuration_inner.h
-    openapi/model/service_access_information_resource_client_metrics_reporting_configuration_inner.c
-    openapi/model/service_access_information_resource_dynamic_policy_invocation_configuration.h
-    openapi/model/service_access_information_resource_dynamic_policy_invocation_configuration.c
-    openapi/model/service_access_information_resource_network_assistance_configuration.h
-    openapi/model/service_access_information_resource_network_assistance_configuration.c
-    openapi/model/service_access_information_resource_streaming_access.h
-    openapi/model/service_access_information_resource_streaming_access.c
-    openapi/model/service_data_flow_description.h
-    openapi/model/service_data_flow_description.c
-    openapi/model/supported_gad_shapes.h
-    openapi/model/supported_gad_shapes.c
-    openapi/model/tai.h
-    openapi/model/tai.c
-    openapi/model/time_window.h
-    openapi/model/time_window.c
-    openapi/model/uncertainty_ellipse.h
-    openapi/model/uncertainty_ellipse.c
-    openapi/model/uncertainty_ellipsoid.h
-    openapi/model/uncertainty_ellipsoid.c
-'''.split()
-
 api_tag = latest_apis?'REL-'+fiveg_api_release:'TSG'+fiveg_api_approval+'-Rel'+fiveg_api_release
 
 gen_5gmsaf_openapi = find_program('sh')
 message('Generating OpenAPI bindings for version '+api_tag+' of the 5G APIs...')
-openapi_gen_result = run_command([gen_5gmsaf_openapi,'-c','"$MESON_SOURCE_ROOT/$MESON_SUBDIR/generator-5gmsaf" -b '+api_tag], check: true, capture: false)
+openapi_dep_file = meson.current_source_dir() / '.openapi.deps'
+openapi_gen_result = run_command([gen_5gmsaf_openapi,'-c','"$MESON_SOURCE_ROOT/$MESON_SUBDIR/generator-5gmsaf" -M '+openapi_dep_file+' -b '+api_tag], check: true, capture: false)
+libmsaf_gen_sources = files(fs.read(openapi_dep_file).split())
 
 json_file = files(['ContentProtocolsDiscovery_body.json'])
 file_content = ''
@@ -228,16 +97,19 @@ libmsaf_sources = libmsaf_dist_sources + libmsaf_gen_sources
 
 libmsaf = static_library('msaf',
     sources : libmsaf_sources,
-    dependencies : [libapp_dep,
-                    libcrypt_dep,
-                    libsbi_dep],
+    include_directories : sbi_openapi_inc,
+    dependencies : [libsbi_dep,
+                    libsbi_openapi_dep,
+                    libapp_dep,
+                    libcrypt_dep],
     install : false)
 
 libmsaf_dep = declare_dependency(
     link_with : libmsaf,
-    dependencies : [libapp_dep,
-                    libcrypt_dep,
-                    libsbi_dep])
+    dependencies : [libsbi_dep,
+                    libsbi_openapi_dep,
+                    libapp_dep,
+                    libcrypt_dep])
 
 msaf_sources = files('''
     app.c
@@ -246,6 +118,8 @@ msaf_sources = files('''
 msaf_config_source = '''
     msaf.yaml
 '''.split()
+
+msaf_include = include_directories('.')
 
 executable('open5gs-msafd',
     sources : msaf_sources,

--- a/src/5gmsaf/meson.build
+++ b/src/5gmsaf/meson.build
@@ -74,8 +74,8 @@ libmsaf_gen_sources = '''
     openapi/model/distribution_configuration.c
     openapi/model/distribution_configuration_geo_fencing.h
     openapi/model/distribution_configuration_geo_fencing.c
-    openapi/model/distribution_configuration_supplementary_distribution_networks.h
-    openapi/model/distribution_configuration_supplementary_distribution_networks.c
+    openapi/model/distribution_configuration_supplementary_distribution_networks_inner.h
+    openapi/model/distribution_configuration_supplementary_distribution_networks_inner.c
     openapi/model/distribution_configuration_url_signature.h
     openapi/model/distribution_configuration_url_signature.c
     openapi/model/distribution_mode.h
@@ -172,8 +172,8 @@ libmsaf_gen_sources = '''
     openapi/model/service_access_information_resource_client_consumption_reporting_configuration.c
     openapi/model/service_access_information_resource_client_edge_resources_configuration.h
     openapi/model/service_access_information_resource_client_edge_resources_configuration.c
-    openapi/model/service_access_information_resource_client_metrics_reporting_configuration.h
-    openapi/model/service_access_information_resource_client_metrics_reporting_configuration.c
+    openapi/model/service_access_information_resource_client_metrics_reporting_configuration_inner.h
+    openapi/model/service_access_information_resource_client_metrics_reporting_configuration_inner.c
     openapi/model/service_access_information_resource_dynamic_policy_invocation_configuration.h
     openapi/model/service_access_information_resource_dynamic_policy_invocation_configuration.c
     openapi/model/service_access_information_resource_network_assistance_configuration.h

--- a/src/5gmsaf/meson.build
+++ b/src/5gmsaf/meson.build
@@ -9,7 +9,7 @@
 
 libapp_dep = open5gs_project.get_variable('libapp_dep')
 libcrypt_dep = open5gs_project.get_variable('libcrypt_dep')
-libsbi_dep = open5gs_project.get_variable('libsbi_dep')
+libsbi_dep = open5gs_project.get_variable('libsbih1_dep')
 open5gs_sysconfdir = open5gs_project.get_variable('open5gs_sysconfdir')
 srcinc = open5gs_project.get_variable('srcinc')
 libdir = open5gs_project.get_variable('libdir')

--- a/src/5gmsaf/msaf-fsm.c
+++ b/src/5gmsaf/msaf-fsm.c
@@ -12,19 +12,17 @@ https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 #include "msaf-fsm.h"
 
 void msaf_fsm_init(void) {
-
     ogs_fsm_init(&msaf_self()->msaf_fsm.msaf_m1_sm, msaf_m1_state_initial, msaf_m1_state_final, 0);
     ogs_fsm_init(&msaf_self()->msaf_fsm.msaf_m5_sm, msaf_m5_state_initial, msaf_m5_state_final, 0);    
-    if(msaf_self()->config.maf_mgmt_server_sockaddr || msaf_self()->config.maf_mgmt_server_sockaddr_v6) {
+    if(msaf_self()->config.servers[MSAF_SVR_MSAF].ipv4 || msaf_self()->config.servers[MSAF_SVR_MSAF].ipv6) {
         ogs_fsm_init(&msaf_self()->msaf_fsm.msaf_maf_mgmt_sm, msaf_maf_mgmt_state_initial, msaf_maf_mgmt_state_final, 0);
     }
-
 }
 
 void msaf_fsm_fini(void) {
     ogs_fsm_fini(&msaf_self()->msaf_fsm.msaf_m1_sm, 0);
     ogs_fsm_fini(&msaf_self()->msaf_fsm.msaf_m5_sm, 0);
-    if(msaf_self()->config.maf_mgmt_server_sockaddr || msaf_self()->config.maf_mgmt_server_sockaddr_v6) {        
+    if(msaf_self()->config.servers[MSAF_SVR_MSAF].ipv4 || msaf_self()->config.servers[MSAF_SVR_MSAF].ipv6) {
         ogs_fsm_fini(&msaf_self()->msaf_fsm.msaf_maf_mgmt_sm, 0);
-    }   
+    }
 }

--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -129,7 +129,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                 }
                 if (!message->h.resource.component[0]) {
                     const char *error = "Protocol on M1 requires a resource";
-                    ogs_error(error);
+                    ogs_error("%s", error);
                     ogs_assert(true == nf_server_send_error(stream, 404, 1, NULL, "No resource given", error, NULL, NULL, app_meta));
                     break;
                 }
@@ -497,20 +497,20 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                             prov_sess = cJSON_Parse(request->http.content);
                             if (!prov_sess) {
                                 const char *err = "createProvisioningSession: Could not parse request body as JSON";
-                                ogs_error(err);
+                                ogs_error("%s", err);
                                 ogs_assert(true == nf_server_send_error(stream, 400, 1, message, "Creation of the Provisioning session failed.", err, NULL, m1_provisioningsession_api, app_meta));
                                 break;
                             }
                             entry = cJSON_GetObjectItemCaseSensitive(prov_sess, "provisioningSessionType");
                             if (!entry) {
                                 const char *err = "createProvisioningSession: \"provisioningSessionType\" is not present";
-                                ogs_error(err);
+                                ogs_error("%s", err);
                                 ogs_assert(true == nf_server_send_error(stream, 400, 1, message, "Creation of the Provisioning session failed.", err, NULL, m1_provisioningsession_api, app_meta));
                                 break;
                             }
                             if (!cJSON_IsString(entry)) {
                                 const char *err = "createProvisioningSession: \"provisioningSessionType\" is not a string";
-                                ogs_error(err);
+                                ogs_error("%s", err);
                                 ogs_assert(true == nf_server_send_error(stream, 400, 1, message, "Creation of the Provisioning session failed.", err, NULL, m1_provisioningsession_api, app_meta));
                                 break;
                             }
@@ -519,13 +519,13 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                             entry = cJSON_GetObjectItemCaseSensitive(prov_sess, "externalApplicationId");
                             if (!entry) {
                                 const char *err = "createProvisioningSession: \"externalApplicationId\" is not present";
-                                ogs_error(err);
+                                ogs_error("%s", err);
                                 ogs_assert(true == nf_server_send_error(stream, 400, 1, message, "Creation of the Provisioning session failed.", err, NULL, m1_provisioningsession_api, app_meta));
                                 break;
                             }
                             if (!cJSON_IsString(entry)) {
                                 const char *err = "createProvisioningSession: \"externalApplicationId\" is not a string";
-                                ogs_error(err);
+                                ogs_error("%s", err);
                                 ogs_assert(true == nf_server_send_error(stream, 400, 1, message, "Creation of the Provisioning session failed.", err, NULL, m1_provisioningsession_api, app_meta));
                                 break;
                             }
@@ -535,7 +535,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                             if (entry) {
                                 if (!cJSON_IsString(entry)) {
                                     const char *err = "createProvisioningSession: \"aspId\" is not a string";
-                                    ogs_error(err);
+                                    ogs_error("%s", err);
                                     ogs_assert(true == nf_server_send_error(stream, 400, 1, message, "Creation of the Provisioning session failed.", err, NULL, m1_provisioningsession_api, app_meta));
                                     break;
                                 }
@@ -563,7 +563,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                 cJSON_Delete(provisioning_session);
                             } else {
                                 const char *err = "Creation of the Provisioning session failed.";
-                                ogs_error(err);
+                                ogs_error("%s", err);
                                 ogs_assert(true == nf_server_send_error(stream, 404, 1, message, "Creation of the Provisioning session failed.", err, NULL, m1_provisioningsession_api, app_meta));
                             }
                             if (prov_sess) cJSON_Delete(prov_sess);
@@ -1136,7 +1136,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                 }              
                 if (!message->h.resource.component[0]) {
                     const char *error = "Resource required for Management interface";
-                    ogs_error(error);
+                    ogs_error("%s", error);
                     ogs_assert(true == nf_server_send_error(stream, 404, 1, NULL, "Resource name required", error, NULL, maf_management_api, app_meta));
                     break;
                 }

--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -89,7 +89,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
 
     msaf_sm_debug(e);
 
-    char *nf_name = ogs_msprintf("5GMSdAF-%s", msaf_self()->server_name);
+    char *nf_name = ogs_msprintf("5GMSAF-%s", msaf_self()->server_name);
     const nf_server_app_metadata_t app_metadata = { MSAF_NAME, MSAF_VERSION, nf_name};
     const nf_server_interface_metadata_t *m1_provisioningsession_api = &m1_provisioningsession_api_metadata;
     const nf_server_interface_metadata_t *m1_contenthostingprovisioning_api = &m1_contenthostingprovisioning_api_metadata;

--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -1015,8 +1015,8 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                        */
                                 } else {
                                     char *err = NULL;
-                                    int number_of_components;
-                                    const nf_server_interface_metadata_t *interface;
+                                    int number_of_components = 0;
+                                    const nf_server_interface_metadata_t *interface = NULL;
                                     if (message->h.resource.component[2]){
                                         if (!strcmp(message->h.resource.component[2],"certificates")) {
                                             number_of_components = 2;
@@ -1411,7 +1411,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
 
                                 ogs_debug("[%s] Method [%s] with Response [%d] recieved for Content Hosting Configuration [%s]", message->h.resource.component[0], message->h.method, response->status,message->h.resource.component[1]);
 
-                                resource_id_node_t *content_hosting_configuration, *next = NULL;
+                                resource_id_node_t *content_hosting_configuration = NULL, *next = NULL;
                                 resource_id_node_t *delete_content_hosting_configuration, *node = NULL;
 
                                 if(as_state->current_content_hosting_configurations) {
@@ -1651,8 +1651,8 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
 
                                 ogs_debug("[%s] Method [%s] with Response [%d] recieved for Certificate [%s]", message->h.resource.component[0], message->h.method, response->status,message->h.resource.component[1]);
 
-                                resource_id_node_t *certificate, *next = NULL;
-                                resource_id_node_t *delete_certificate, *node = NULL;
+                                resource_id_node_t *certificate = NULL, *next = NULL;
+                                resource_id_node_t *delete_certificate = NULL, *node = NULL;
 
                                 if(as_state->current_certificates) {
                                     ogs_list_for_each_safe(as_state->current_certificates, next, certificate){

--- a/src/5gmsaf/msaf-m5-sm.c
+++ b/src/5gmsaf/msaf-m5-sm.c
@@ -49,7 +49,7 @@ void msaf_m5_state_functional(ogs_fsm_t *s, msaf_event_t *e)
 
     msaf_sm_debug(e);
 
-    char *nf_name = ogs_msprintf("5GMSdAF-%s", msaf_self()->server_name);
+    char *nf_name = ogs_msprintf("5GMSAF-%s", msaf_self()->server_name);
     const nf_server_app_metadata_t app_metadata = { MSAF_NAME, MSAF_VERSION, nf_name};
     const nf_server_interface_metadata_t *m5_serviceaccessinformation_api = &m5_serviceaccessinformation_api_metadata;
     const nf_server_app_metadata_t *app_meta = &app_metadata;

--- a/src/5gmsaf/msaf-mgmt-sm.c
+++ b/src/5gmsaf/msaf-mgmt-sm.c
@@ -48,7 +48,7 @@ void msaf_maf_mgmt_state_functional(ogs_fsm_t *s, msaf_event_t *e)
     msaf_sm_debug(e);
 
     if (!msaf_self()->server_name[0]) msaf_context_server_name_set();
-    char *nf_name = ogs_msprintf("5GMSdAF-%s", msaf_self()->server_name);
+    char *nf_name = ogs_msprintf("5GMSAF-%s", msaf_self()->server_name);
     const nf_server_app_metadata_t app_metadata = { MSAF_NAME, MSAF_VERSION, nf_name};
     const nf_server_interface_metadata_t *maf_management_api = &maf_mgmt_api_metadata;
     const nf_server_app_metadata_t *app_meta = &app_metadata;

--- a/src/5gmsaf/msaf-sm.c
+++ b/src/5gmsaf/msaf-sm.c
@@ -132,7 +132,7 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                 break;
 
             CASE("3gpp-m1")
-                if(check_event_addresses(e, msaf_self()->config.m1_server_sockaddr, msaf_self()->config.m1_server_sockaddr_v6)){
+                if(check_event_addresses(e, msaf_self()->config.servers[MSAF_SVR_M1].ipv4, msaf_self()->config.servers[MSAF_SVR_M1].ipv6)){
                     e->message = message;
                     message = NULL;
                     ogs_fsm_dispatch(&msaf_self()->msaf_fsm.msaf_m1_sm, e);
@@ -145,13 +145,7 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                 break;
             
             CASE("5gmag-rt-management")
-                if(!msaf_self()->config.maf_mgmt_server_sockaddr && !msaf_self()->config.maf_mgmt_server_sockaddr_v6) {
-                    if(check_event_addresses(e, msaf_self()->config.m1_server_sockaddr, msaf_self()->config.m1_server_sockaddr_v6)){
-                        e->message = message;
-                        message = NULL;
-                        ogs_fsm_dispatch(&msaf_self()->msaf_fsm.msaf_m1_sm, e);
-                    }
-                } else if(check_event_addresses(e, msaf_self()->config.maf_mgmt_server_sockaddr, msaf_self()->config.maf_mgmt_server_sockaddr_v6)){
+                if(check_event_addresses(e, msaf_self()->config.servers[MSAF_SVR_MSAF].ipv4, msaf_self()->config.servers[MSAF_SVR_MSAF].ipv6)){
                     e->message = message;
                     message = NULL;
                     ogs_fsm_dispatch(&msaf_self()->msaf_fsm.msaf_maf_mgmt_sm, e);
@@ -165,11 +159,10 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                 break;   
 
             CASE("3gpp-m5")
-                if(check_event_addresses(e, msaf_self()->config.m5_server_sockaddr, msaf_self()->config.m5_server_sockaddr_v6)){
+                if(check_event_addresses(e, msaf_self()->config.servers[MSAF_SVR_M5].ipv4, msaf_self()->config.servers[MSAF_SVR_M5].ipv6)){
                     e->message = message;
                     message = NULL;
                     ogs_fsm_dispatch(&msaf_self()->msaf_fsm.msaf_m5_sm, e);
-
                 } else {
                     char *error;
                     error = ogs_msprintf("Resource [%s] not found.", request->h.uri);

--- a/src/5gmsaf/msaf-sm.c
+++ b/src/5gmsaf/msaf-sm.c
@@ -286,7 +286,12 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                     ogs_assert(subscription_data);
 
                     ogs_assert(true ==
-                            ogs_nnrf_nfm_send_nf_status_subscribe(subscription_data));
+                            ogs_nnrf_nfm_send_nf_status_subscribe(
+                            ogs_sbi_self()->nf_instance->nf_type,
+                            subscription_data->req_nf_instance_id,
+                            subscription_data->subscr_cond.nf_type,
+                            subscription_data->subscr_cond.service_name));
+
 
                     ogs_debug("Subscription validity expired [%s]",
                             subscription_data->id);

--- a/src/5gmsaf/msaf-sm.c
+++ b/src/5gmsaf/msaf-sm.c
@@ -54,7 +54,7 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
 
     message = ogs_calloc(1, sizeof(*message));
     msaf_context_server_name_set();
-    char *nf_name = ogs_msprintf("5GMSdAF-%s", msaf_self()->server_name);
+    char *nf_name = ogs_msprintf("5GMSAF-%s", msaf_self()->server_name);
     const nf_server_app_metadata_t app_metadata = { MSAF_NAME, MSAF_VERSION, nf_name};
     const nf_server_app_metadata_t *app_meta = &app_metadata;
 

--- a/src/5gmsaf/msaf.yaml.in
+++ b/src/5gmsaf/msaf.yaml.in
@@ -31,6 +31,43 @@ logger:
 logger:
 #    file: /home/ubuntu/af/open5gs/build/log/msaf.log
 #
+
+# sbi:
+#   Global SBI parameters
+#
+# o No Server TLS - Client connection can use TLS without certificates
+#   server:
+#     no_tls: true
+#   client:
+#     no_tls: true
+#
+# o Server TLS used - Client connection can use TLS without certificates
+#   server:
+#     no_tls: false
+#     cacert: /path/to/tls/trusted/ca.crt
+#     key: /path/to/tls/private/testserver.key
+#     cert: /path/to/tls/public/testserver.crt
+#   client:
+#     no_tls: true
+#
+# o Server TLS used - Client TLS certificates used
+#   server:
+#     no_tls: false
+#     cacert: /path/to/tls/trusted/ca.crt
+#     key: /path/to/tls/private/testserver.key
+#     cert: /path/to/tls/public/testserver.crt
+#   client:
+#     no_tls: false
+#     cacert: /path/to/tls/trusted/ca.crt
+#     key: /path/to/tls/private/testclient.key
+#     cert: /path/to/tls/public/testclient.crt
+#
+sbi:
+  server:
+    no_tls: true
+  client:
+    no_tls: true
+
 # udm:
 #
 #  <SBI Server>

--- a/src/5gmsaf/provisioning-session.c
+++ b/src/5gmsaf/provisioning-session.c
@@ -461,7 +461,7 @@ cJSON *msaf_get_content_hosting_configuration_by_provisioning_session_id(const c
     {
        content_hosting_configuration_json = OpenAPI_content_hosting_configuration_convertToJSON(msaf_provisioning_session->contentHostingConfiguration);
     } else {
-        ogs_error("Unable to retrieve Provisioning Session [%s]", provisioning_session_id);
+        ogs_error("Unable to retrieve ContentHostingConfiguration for Provisioning Session [%s]", provisioning_session_id);
     }
     return content_hosting_configuration_json;
 }

--- a/src/5gmsaf/provisioning-session.c
+++ b/src/5gmsaf/provisioning-session.c
@@ -342,7 +342,7 @@ msaf_distribution_create(cJSON *content_hosting_config, msaf_provisioning_sessio
     static const char macro[] = "{provisioningSessionId}";
     msaf_application_server_node_t *msaf_as = NULL;
     char *content_hosting_config_to_hash = NULL;
-    OpenAPI_list_t *media_entry_point_list;
+    OpenAPI_list_t *media_entry_point_list = NULL;
     OpenAPI_list_t *media_entry_point_profiles_list = NULL;
     OpenAPI_m5_media_entry_point_t *entry_point;
     char *locator_absolute_path;

--- a/src/5gmsaf/sbi-path.c
+++ b/src/5gmsaf/sbi-path.c
@@ -44,9 +44,9 @@ int msaf_sbi_open(void)
     ogs_assert(nf_instance);
     ogs_sbi_nf_fsm_init(nf_instance);
 
-    ogs_sbi_nf_instance_build_default(nf_instance, OpenAPI_nf_type_AF);
+    ogs_sbi_nf_instance_build_default(nf_instance);
 
-    ogs_sbi_subscription_data_build_default(
+    ogs_sbi_subscription_spec_add(
             OpenAPI_nf_type_BSF, OGS_SBI_SERVICE_NAME_NBSF_MANAGEMENT);
 
     if (ogs_sbi_server_start_all(server_cb) != OGS_OK)

--- a/src/5gmsaf/server.c
+++ b/src/5gmsaf/server.c
@@ -32,7 +32,7 @@ ogs_sbi_response_t *nf_server_new_response(char *location, char *content_type, t
     char *server = NULL;
 
     response = ogs_sbi_response_new();
-    ogs_expect_or_return_val(response, NULL);
+    ogs_expect(response);
 
     if(content_type)
     {
@@ -138,7 +138,7 @@ bool nf_server_send_error(ogs_sbi_stream_t *stream,
         int i;
         problem.type = ogs_msprintf("/%s/%s",
                 message->h.service.name, message->h.api.version);
-        ogs_expect_or_return_val(problem.type, false);
+        ogs_expect(problem.type);
 
         problem.instance = ogs_msprintf("/%s", message->h.resource.component[0]);
 
@@ -149,7 +149,7 @@ bool nf_server_send_error(ogs_sbi_stream_t *stream,
             ogs_free(problem.instance);
             problem.instance = instance;
         }
-        ogs_expect_or_return_val(problem.instance, NULL);
+        ogs_expect(problem.instance);
     }
     if (status) {
         problem.is_status = true;
@@ -183,14 +183,13 @@ static ogs_sbi_response_t *nf_build_response(ogs_sbi_message_t *message, int sta
 
     response = nf_server_new_response(NULL, NULL, 0, NULL, 0, NULL, interface, app);
 
-    //response = ogs_sbi_response_new();
-    ogs_expect_or_return_val(response, NULL);
+    ogs_expect(response);
 
     response->status = status;
 
     if (response->status != OGS_SBI_HTTP_STATUS_NO_CONTENT) {
-        ogs_expect_or_return_val(true ==
-                nf_build_content(&response->http, message), NULL);
+        ogs_expect(true ==
+                nf_build_content(&response->http, message));
     }
 
     if (message->http.location) {

--- a/subprojects/patch_open5gs.sh
+++ b/subprojects/patch_open5gs.sh
@@ -65,6 +65,18 @@ index 67a1badc7..573582c2e 100644
 +                    libnghttp2_dep,
 +                    libmicrohttpd_dep,
 +                    libcurl_dep])
+diff --git a/lib/sbi/openapi/meson.build b/lib/sbi/openapi/meson.build
+index b3a507bd3..5f6388a0f 100644
+--- a/lib/sbi/openapi/meson.build
++++ b/lib/sbi/openapi/meson.build
+@@ -1370,6 +1370,7 @@ libsbi_openapi_sources = files('''
+ '''.split())
+
+ libsbi_openapi_inc = include_directories('.')
++libsbi_openapi_model_inc = include_directories('model')
+
+ sbi_openapi_cc_flags = ['-DOGS_SBI_COMPILATION']
+
 diff --git a/lib/sbi/server.c b/lib/sbi/server.c
 index af5cb8aad..5a20728a9 100644
 --- a/lib/sbi/server.c

--- a/tools/bash/certmgr
+++ b/tools/bash/certmgr
@@ -78,13 +78,13 @@ CERTOP:
   list		List the available certificates/keys
 
 newcsr parameters:
-  syntax: newcsr <certificate-id>
+  syntax: newcsr <certificate-id> <common-name> [<extra-domain-name>...]
 
   certificate-id        The certificate ID to create a new key and certificate
                         signing request.
 
 newcert parameters:
-  syntax: newcert <certificate-id>
+  syntax: newcert <certificate-id> <common-name>
 
   certificate-id	The certificate ID to create a new key and public
                         certificate.
@@ -187,12 +187,28 @@ cert_store_check() {
     fi
 }
 
+fqdn_check() {
+    fqdn="$1"
+    if echo "$fqdn" | grep -viq '^[a-z0-9][-a-z0-9]*\(\.[a-z0-9][-a-z0-9]*\)*$'; then
+	error_exit 3 "Bad domain name: $fqdn"
+    fi
+}
+
 new_csr() {
     cert_id="$1"
     common_name="$2"
+    shift 2
     cert_store_check "$cert_id"
+    fqdn_check "$common_name"
 
-    openssl req -new -newkey rsa:2048 -batch -nodes -keyout "$cert_store/private/$cert_id.pem" -out "$cert_store/csrs/$cert_id.pem" -subj "/C=GB/L=London/CN=$common_name" -addext "subjectAltName=DNS:$common_name" > /dev/null 2>&1
+    extra_domain_args=""
+    while [ "$#" -gt "0" ]; do
+	fqdn_check "$1"
+	extra_domain_args=",DNS:$1"
+	shift
+    done
+
+    openssl req -new -newkey rsa:2048 -batch -nodes -keyout "$cert_store/private/$cert_id.pem" -out "$cert_store/csrs/$cert_id.pem" -subj "/C=GB/L=London/CN=$common_name" -addext "subjectAltName=DNS:$common_name$extra_domain_args" > /dev/null 2>&1
 
     ts=`stat -c '%Y' "$cert_store/csrs/$cert_id.pem"`
     timestamp=`TZ=GMT date --date=@$ts +'%a, %d %b %Y %H:%M:%S %Z'`
@@ -366,7 +382,7 @@ certificate_delete() {
 
 parse_opts() {
     if [ "$CERTOPS" == "newcsr" ]; then
-        if [ $# -ne 2 ]; then
+        if [ $# -lt 2 ]; then
             echo "$CERTOPS: Wrong parameters to create a new csr"
             exit 1
         fi

--- a/tools/python3/lib/rt_m1_client/certificates/acme_cert_signer.py
+++ b/tools/python3/lib/rt_m1_client/certificates/acme_cert_signer.py
@@ -54,24 +54,6 @@ from ..data_store import DataStore
 
 LOGGER = logging.getLogger(__name__)
 
-__byteval_re_str = r'(?:[0-9]{1,2}|[01][0-9][0-9]|2(?:[0-4][0-9]|5[0-5]))'
-__ipv4_re_str = fr'{__byteval_re_str}(?:\.{__byteval_re_str}){{3}}'
-__hexdigits_re_str = r'[0-9a-fA-F]{1,4}'
-__ipv6_8_re_str = fr'(?:{__hexdigits_re_str}:){{7}}{__hexdigits_re_str}'
-__ipv6_dcoln_0_re_str = fr'(?:{__hexdigits_re_str}:){{1,7}}:'
-__ipv6_dcoln_1_re_str = fr'(?:{__hexdigits_re_str}:){{1,6}}:{__hexdigits_re_str}'
-__ipv6_dcoln_2_re_str = fr'(?:{__hexdigits_re_str}:){{1,5}}(?::{__hexdigits_re_str}){{2}}'
-__ipv6_dcoln_3_re_str = fr'(?:{__hexdigits_re_str}:){{1,4}}(?::{__hexdigits_re_str}){{3}}'
-__ipv6_dcoln_4_re_str = fr'(?:{__hexdigits_re_str}:){{1,3}}(?::{__hexdigits_re_str}){{4}}'
-__ipv6_dcoln_5_re_str = fr'(?:{__hexdigits_re_str}:){{1,2}}(?::{__hexdigits_re_str}){{5}}'
-__ipv6_dcoln_6_re_str = fr'{__hexdigits_re_str}:(?::{__hexdigits_re_str}){{6}}'
-__ipv6_dcoln_7_re_str = fr':(?::{__hexdigits_re_str}){{7}}'
-__ipv6_site_hw_re_str = fr'fe80::(?:{__hexdigits_re_str}(?::{__hexdigits_re_str}){{0,3}})?%[0-9a-zA-Z]{{1,}}'
-__ipv6_enc_ipv4_re_str = fr'::(?:ffff(?::0{{1,4}})?:)?{__ipv4_re_str}'
-__ipv6_emb_ipv4_re_str = fr'(?:{__hexdigits_re_str}:){{1,4}}:{__ipv4_re_str}'
-__ipv6_re_str = fr'(?:{__ipv6_8_re_str}|{__ipv6_dcoln_0_re_str}|{__ipv6_dcoln_1_re_str}|{__ipv6_dcoln_2_re_str}|{__ipv6_dcoln_3_re_str}|{__ipv6_dcoln_4_re_str}|{__ipv6_dcoln_5_re_str}|{__ipv6_dcoln_6_re_str}|{__ipv6_dcoln_7_re_str}|{__ipv6_site_hw_re_str}|{__ipv6_enc_ipv4_re_str}|{__ipv6_emb_ipv4_re_str})'
-_ip_address_re = re.compile(fr'^(?:{__ipv6_re_str}|{__ipv4_re_str})$')
-
 class ACMECertificateSigner(CertificateSigner):
     '''ACMECertificateSigner class
 
@@ -87,14 +69,13 @@ class ACMECertificateSigner(CertificateSigner):
     LetsEncryptStagingService: str = 'https://acme-staging-v02.api.letsencrypt.org/directory'
     LetsEncryptService: str = 'https://acme-v02.api.letsencrypt.org/directory'
 
-    def __init__(self, *args, acme_service: Optional[str] = None, docroots_dir: Optional[str] = None, default_docroot_dir: Optional[str] = None, private_keys_dir: Optional[str] = None, data_store: Optional[DataStore] = None, **kwargs):
+    def __init__(self, *args, acme_service: Optional[str] = None, docroots_dir: Optional[str] = None, default_docroot_dir: Optional[str] = None, data_store: Optional[DataStore] = None, **kwargs):
         '''Constructor
 
         :param acme_service: The URL of the ACME directory service to use for certificate signing.
         :param docroots_dir: The directory that contains all the document roots for the virtual hosts, each host has a directory
                              whose name is the FQDN of the virtual host.
         :param default_docroot_dir: The directory which is the docroot of the default virtual host.
-        :param private_keys_dir: The directory which contains the private key store for the 5GMS Application Function.
         :param data_store: The persistent data store object to use for data persistence.
         '''
         errs=[]
@@ -104,15 +85,12 @@ class ACMECertificateSigner(CertificateSigner):
             errs += ['docroots_dir is None']
         if default_docroot_dir is None:
             errs += ['default_docroot_dir is None']
-        if private_keys_dir is None:
-            errs += ['private_keys_dir is None']
         if len(errs) != 0:
             raise RuntimeError(f'{self.__class__.__name__} instantiated without needed parameters: {", ".join(errs)}')
         super().__init__(*args, data_store=data_store, **kwargs)
         self.__acme_service: str = acme_service
         self.__docroots: str = docroots_dir
         self.__default_docroot: str = default_docroot_dir
-        self.__private_keys_dir: str = private_keys_dir
 
     async def asyncInit(self):
         '''Asynchronous object initialisation
@@ -123,7 +101,7 @@ class ACMECertificateSigner(CertificateSigner):
         '''
         return self
 
-    async def signCertificate(self, csr: str, *args, domain_name_alias: Optional[str] = None, **kwargs) -> Optional[str]:
+    async def signCertificate(self, csr: str, *args, **kwargs) -> Optional[str]:
         '''Sign a CSR in PEM format and return the public X509 Certificate in PEM format
 
         :param str csr: A CSR in PEM format.
@@ -134,46 +112,15 @@ class ACMECertificateSigner(CertificateSigner):
         This will use the *csr* as a guideline for talking to the ACME server. The *domain_name_alias* will be used for the common name and first SAN, if the common name or SANs from the *csr* are not private IPs or localhost references then they will also be included.
         '''
         x509req: OpenSSL.crypto.X509Req = OpenSSL.crypto.load_certificate_request(OpenSSL.crypto.FILETYPE_PEM, csr.encode('utf-8'))
-        acmeReq: OpenSSL.crypto.X509Req = OpenSSL.crypto.X509Req()
-        # build SAN list
-        sans: List[bytes] = []
-        if domain_name_alias is not None:
-            sans += [domain_name_alias.encode('utf-8')]
-        common_name = x509req.get_subject().commonName
-        if isinstance(common_name,str):
-            common_name = common_name.encode('utf-8')
-        if common_name != b'localhost' and _ip_address_re.match(common_name.decode('utf-8')) is None:
-            sans += [common_name]
-
-        if len(sans) == 0:
-            return None
-
-        # Copy the CSR version number
-        acmeReq.set_version(x509req.get_version())
-
-        # Copy across the public key
-        pkey = await self.__get_private_key_for_public_key(x509req.get_pubkey())
-        if pkey is None:
-            return None
-        acmeReq.set_pubkey(pkey)
-
-        # Set the common name to first SAN
-        self.__copy_X509Name(acmeReq.get_subject(), x509req.get_subject()).commonName = sans[0]
-
-        # Add extensions
-        acmeReq.add_extensions([
-            OpenSSL.crypto.X509Extension(b'basicConstraints', True, b'CA:FALSE'),
-            OpenSSL.crypto.X509Extension(b'subjectAltName', False, b','.join([b'DNS:'+san for san in sans]))
-            ])
-
-        # Sign the new CSR
-        acmeReq.sign(pkey, "sha256")
 
         # Send request to ACME server
-        acmeReqBytes: bytes = OpenSSL.crypto.dump_certificate_request(OpenSSL.crypto.FILETYPE_PEM, acmeReq)
+        acmeReqBytes: bytes = OpenSSL.crypto.dump_certificate_request(OpenSSL.crypto.FILETYPE_PEM, x509req)
         async with aiofiles.tempfile.NamedTemporaryFile('wb', delete=False) as f:
             await f.write(acmeReqBytes)
-        domain_docroot = os.path.join(self.__docroots, sans[0].decode('utf-8'))
+        common_name = x509req.get_subject().commonName
+        if isinstance(common_name,bytes):
+            common_name = common_name.decode('utf-8')
+        domain_docroot = os.path.join(self.__docroots, common_name)
         old_umask = os.umask(0)
         try:
             await aiofiles.os.makedirs(domain_docroot, mode=0o755, exist_ok=True)
@@ -192,57 +139,6 @@ class ACMECertificateSigner(CertificateSigner):
         await aiofiles.os.remove(f.name)
         return certdata
 
-    @staticmethod
-    def __copy_X509Name(dest: OpenSSL.crypto.X509Name, src: OpenSSL.crypto.X509Name) -> OpenSSL.crypto.X509Name:
-        '''Copy an X509Name into another X509Name
-
-        :param dest: The destination X509Name to be overwritten.
-        :param src: The source X509Name to get values from.
-
-        :return: *dest*
-        '''
-        dest.__init__(src)
-        return dest
-
-    async def __get_private_key_for_public_key(self, pubkey: OpenSSL.crypto.PKey) -> Optional[OpenSSL.crypto.PKey]:
-        '''Find the private key for a given public key
-
-        This will search the *private_keys_dir* directory given in the constructor for a private key which matches the *pubkey* public key.
-
-        :param pubkey: The public key to find the matching private key for.
-
-        :return: the private key or None if the key could not be found.
-        '''
-        # search self.__private_keys_dir directory for the private key that matches the public key we have and return it
-        if self.__private_keys_dir is None:
-            LOGGER.debug('No private keys directory configured, unable to match private key to public key')
-            return None
-        LOGGER.debug(f'Looking for private key in {self.__private_keys_dir}')
-        try:
-            for entry in await aiofiles.os.scandir(self.__private_keys_dir):
-                #LOGGER.debug(f'Checking directory entry {entry.name}')
-                if entry.is_file():
-                    try:
-                        async with aiofiles.open(os.path.join(self.__private_keys_dir,entry.name), mode='rb') as keyfile:
-                            pkey = OpenSSL.crypto.load_privatekey(OpenSSL.crypto.FILETYPE_PEM, await keyfile.read())
-                            #LOGGER.debug(f'Loaded PKey {pkey}')
-                            if pkey.to_cryptography_key().public_key().public_bytes(cryptography_Encoding.PEM, cryptography_PublicFormat.SubjectPublicKeyInfo) == pubkey.to_cryptography_key().public_bytes(cryptography_Encoding.PEM, cryptography_PublicFormat.SubjectPublicKeyInfo):
-                                LOGGER.debug(f'{entry.name} matches public key')
-                                return pkey
-                    except OpenSSL.crypto.Error:
-                        LOGGER.debug(f'{entry.name} bad key file, skipping')
-                        pass
-                    except FileNotFoundError:
-                        LOGGER.warn(f'{entry.name} disappeared while scanning private keys')
-                        pass
-                    except PermissionError:
-                        LOGGER.warn(f'{entry.name} not accessible')
-                        pass
-        except FileNotFoundError as err:
-            LOGGER.warn(f'Configured private keys directory ({self.__private_keys_dir}) not found: {err}')
-            pass
-        return None
-
 async def _run_certbot_app(cmd_args: List[str]) -> Tuple[int, bytes]:
     '''Run `certbot` using the given command line arguments
 
@@ -257,21 +153,21 @@ async def _run_certbot_app(cmd_args: List[str]) -> Tuple[int, bytes]:
     data = await proc.stdout.read()
     return (proc.returncode, data)
 
-async def LetsEncryptCertificateSigner(*args, docroots_dir: Optional[str] = None, default_docroot_dir: Optional[str] = None, private_keys_dir: Optional[str] = None, data_store: Optional[DataStore] = None, **kwargs) -> ACMECertificateSigner:
+async def LetsEncryptCertificateSigner(*args, docroots_dir: Optional[str] = None, default_docroot_dir: Optional[str] = None, data_store: Optional[DataStore] = None, **kwargs) -> ACMECertificateSigner:
     '''Let's Encrypt ACMECertificateSigner factory function
 
     Creates an ACMECertificateSigner with *acme_service* set to the Let's Encrypt live service URL and other parameters passed through.
 
     :return: a new ACMECertificateSigner which will use Let's Encrypt.
     '''
-    return await ACMECertificateSigner(*args, acme_service=ACMECertificateSigner.LetsEncryptService, docroots_dir=docroots_dir, default_docroot_dir=default_docroot_dir, private_keys_dir=private_keys_dir, data_store=data_store, **kwargs)
+    return await ACMECertificateSigner(*args, acme_service=ACMECertificateSigner.LetsEncryptService, docroots_dir=docroots_dir, default_docroot_dir=default_docroot_dir, data_store=data_store, **kwargs)
 
-async def TestLetsEncryptCertificateSigner(*args, docroots_dir: Optional[str] = None, default_docroot_dir: Optional[str] = None, private_keys_dir: Optional[str] = None, data_store: Optional[DataStore] = None, **kwargs) -> ACMECertificateSigner:
+async def TestLetsEncryptCertificateSigner(*args, docroots_dir: Optional[str] = None, default_docroot_dir: Optional[str] = None, data_store: Optional[DataStore] = None, **kwargs) -> ACMECertificateSigner:
     '''Let's Encrypt staging (test) service ACMECertificateSigner factory function
 
     Creates an ACMECertificateSigner with *acme_service* set to the Let's Encrypt staging service URL and other parameters passed through.
 
     :return: a new ACMECertificateSigner which will use Let's Encrypt staging service.
     '''
-    return await ACMECertificateSigner(*args, acme_service=ACMECertificateSigner.LetsEncryptStagingService, docroots_dir=docroots_dir, default_docroot_dir=default_docroot_dir, private_keys_dir=private_keys_dir, data_store=data_store, **kwargs)
+    return await ACMECertificateSigner(*args, acme_service=ACMECertificateSigner.LetsEncryptStagingService, docroots_dir=docroots_dir, default_docroot_dir=default_docroot_dir, data_store=data_store, **kwargs)
 

--- a/tools/python3/lib/rt_m1_client/certificates/base.py
+++ b/tools/python3/lib/rt_m1_client/certificates/base.py
@@ -58,11 +58,10 @@ class CertificateSigner:
         '''
         return self
 
-    async def signCertificate(self, csr: str, *args, domain_name_alias: Optional[str] = None, **kwargs) -> Optional[str]:
+    async def signCertificate(self, csr: str, *args, **kwargs) -> Optional[str]:
         '''Sign a CSR in PEM format and return the public X509 Certificate in PEM format
 
         :param str csr: A CSR in PEM format.
-        :param str domain_name_alias: Optional domain name to add to the subjectAltNames in the final certificate.
 
         :return: a public X509 certificate in PEM format.
         '''

--- a/tools/python3/lib/rt_m1_client/certificates/local_ca_cert_signer.py
+++ b/tools/python3/lib/rt_m1_client/certificates/local_ca_cert_signer.py
@@ -57,35 +57,23 @@ class LocalCACertificateSigner(CertificateSigner):
         self.__temp_ca_days: int = temp_ca_days
         self.__local_cert_days: int = local_cert_days
 
-    async def signCertificate(self, csr: str, *args, domain_name_alias: Optional[str] = None, **kwargs) -> Optional[str]:
+    async def signCertificate(self, csr: str, *args, **kwargs) -> Optional[str]:
         '''Sign a CSR in PEM format and return the public X509 Certificate in PEM format
 
         This will generate a public certificate from the *csr*, which is signed by the locally generated CA.
-        The certificate will have subjectAltNames defined for the SANs in the *csr*, the commonName and optionally the
-        *domain_name_alias*. The certificate will expire in the number of days indicated by the *local_cert_days* parameter
-        when an instance of this class was created.
+        The certificate will have subjectAltNames defined for the SANs in the *csr* and the commonName. The certificate will expire
+        in the number of days indicated by the *local_cert_days* parameter when an instance of this class was created.
 
         :param str csr: A CSR in PEM format.
-        :param str domain_name_alias: Optional domain name to add to the subjectAltNames in the final certificate.
 
         :return: a public X509 certificate in PEM format, or None on error.
         '''
         x509req: OpenSSL.crypto.X509Req = OpenSSL.crypto.load_certificate_request(OpenSSL.crypto.FILETYPE_PEM, csr.encode('utf-8'))
-        # Adjust SANs
-        sans: List[bytes] = []
-        if domain_name_alias is not None:
-            sans += [b'DNS:'+domain_name_alias.encode('utf-8')]
-        sans += [b'DNS:'+x509req.get_subject().commonName.encode('utf-8')]
         # Get local CA
         ca_key, ca = await self.__getLocalCA()
         # Convert CSR to X509 certificate
         x509 = OpenSSL.crypto.X509()
-        if domain_name_alias is not None:
-            new_subj = x509.get_subject()
-            new_subj.commonName = domain_name_alias
-            new_subj.organizationName = '5G-MAG'
-        else:
-            x509.set_subject(x509req.get_subject())
+        x509.set_subject(x509req.get_subject())
         x509.set_serial_number(1)
         x509.gmtime_adj_notBefore(0)
         x509.gmtime_adj_notAfter(self.__local_cert_days * 24 * 60 * 60)
@@ -93,13 +81,12 @@ class LocalCACertificateSigner(CertificateSigner):
         x509.set_pubkey(x509req.get_pubkey())
         # Copy any extensions we aren't replacing
         for ext in x509req.get_extensions():
-            if ext.get_short_name() not in [b'subjectKeyIdentifier', b'authorityKeyIdentifier', b'basicConstraints', b'subjectAltName']:
+            if ext.get_short_name() not in [b'subjectKeyIdentifier', b'authorityKeyIdentifier', b'basicConstraints']:
                 x509.add_extensions([ext])
         x509.add_extensions([
             OpenSSL.crypto.X509Extension(b'subjectKeyIdentifier', False, b'hash', subject=x509),
             OpenSSL.crypto.X509Extension(b'authorityKeyIdentifier', False, b'keyid, issuer', issuer=ca),
-            OpenSSL.crypto.X509Extension(b'basicConstraints', True, b'CA:FALSE'),
-            OpenSSL.crypto.X509Extension(b'subjectAltName', False, b','.join(sans))
+            OpenSSL.crypto.X509Extension(b'basicConstraints', True, b'CA:FALSE')
             ])
         x509.sign(ca_key, "sha256")
         return OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_PEM, x509).decode('utf-8')

--- a/tools/python3/lib/rt_m1_client/client.py
+++ b/tools/python3/lib/rt_m1_client/client.py
@@ -378,6 +378,8 @@ class M1Client:
         '''
 
         url = f'/provisioning-sessions/{provisioning_session_id}/certificates'
+        if extra_domain_names is not None and not isinstance(extra_domain_names,list):
+            raise M1ServerError(reason = f'Bad parameter passed during certificate creation', status_code = 500)
         if csr:
             url += '?csr=true'
         elif extra_domain_names is not None and len(extra_domain_names) > 0:

--- a/tools/python3/lib/rt_m1_client/session.py
+++ b/tools/python3/lib/rt_m1_client/session.py
@@ -406,6 +406,13 @@ class M1Session:
         :return: The certificate id of the newly created certificate or ``None`` if the certificate could not be created.
         '''
         # simple case just create the certificate
+        if extra_domain_names is not None and isinstance(extra_domain_names, bytes):
+            extra_domain_names = extra_domain_names.decode('utf-8')
+        if extra_domain_names is not None and isinstance(extra_domain_names, str):
+            if len(extra_domain_names) > 0:
+                extra_domain_names = [extra_domain_names]
+            else:
+                extra_domain_names = None
         if extra_domain_names is not None and len(extra_domain_names) == 0:
             extra_domain_names = None
         if extra_domain_names is None:

--- a/tools/python3/m1_sync_config.py
+++ b/tools/python3/m1_sync_config.py
@@ -312,7 +312,7 @@ async def sync_configuration(m1: M1Session, streams: dict) -> dict:
             for dc in chc['distributionConfigurations']:
                 if 'certificateId' in dc:
                     if dc['certificateId'] not in certs:
-                        cert_id = await m1.createNewCertificate(ps_id, domain_name_alias = dc.get('domainNameAlias', None))
+                        cert_id = await m1.createNewCertificate(ps_id, extra_domain_names=dc.get('domainNameAlias', None))
                         if cert_id is None:
                             log_error("Failed to create certificate for Provisioning Session %s, skipping %r", ps_id, cfg)
                             chc = None


### PR DESCRIPTION
This PR pulls in some uplifts for:
- TS 26.512 V17.4.0
  - Updates `Server` response header to match the change in specification.
- TS 26.512 V17.6.0
  - Uses TSG100-Rel17 release of the APIs for the 5GMS AF.
  - Adds handling of multiple domain names during CSR creation.
- Open5GS (Release 16 => Release 17 uplift)

It also includes a modification to the 5GMS Application Function build system to automatically determine which OpenAPI model source codes have been generated, and include them in the compile, rather than the files having to be explicitly named in the build file.

Note also that a new configuration file variable, `msaf.m3Host`, has been added so that the 5GMS AF can use an internal network to talk to the 5GMS AS via M3 rather than having to share the canonical hostname (which is used with M2). This allows the SSL/TLS certificate to be generated with the names of interfaces other than the one used by the internal M3 link. By default, if this new configuration variable is not given, the canonical hostname will be used for M3 as before.

Closes: #60, #80, #81 and #82