### PR TITLE
Feature: M1 - Consumption Reporting Provisioning

### DIFF
--- a/src/5gmsaf/application-server-context.c
+++ b/src/5gmsaf/application-server-context.c
@@ -379,10 +379,10 @@ static int m3_client_as_state_requests(msaf_application_server_state_node_t *as_
     const char *m3_host;
 
     m3_host = as_state->application_server->m3Host?
-	    as_state->application_server->m3Host:
-	    as_state->application_server->canonicalHostname;
+            as_state->application_server->m3Host:
+            as_state->application_server->canonicalHostname;
     request = ogs_sbi_request_new();
-    request->h.method = msaf_strdup(method);	
+    request->h.method = msaf_strdup(method);
     request->h.uri = ogs_msprintf("http://%s:%i/3gpp-m3/v1/%s", m3_host, as_state->application_server->m3Port, component);
     request->h.api.version = msaf_strdup("v1");
     if (data) {
@@ -404,7 +404,7 @@ static int m3_client_as_state_requests(msaf_application_server_state_node_t *as_
     ogs_sbi_request_free(request);
 
     return 1;
-}		
+}
 
 static int client_notify_cb(int status, ogs_sbi_response_t *response, void *data)
 {

--- a/src/5gmsaf/application-server-context.h
+++ b/src/5gmsaf/application-server-context.h
@@ -37,7 +37,7 @@ typedef struct msaf_application_server_state_node_s {
     ogs_list_t       *current_content_hosting_configurations;
     ogs_list_t        upload_content_hosting_configurations;
     ogs_list_t        delete_content_hosting_configurations;
-    ogs_list_t	      purge_content_hosting_cache;
+    ogs_list_t        purge_content_hosting_cache;
 } msaf_application_server_state_node_t;
 
 typedef struct assigned_provisioning_sessions_node_s {

--- a/src/5gmsaf/certmgr.c
+++ b/src/5gmsaf/certmgr.c
@@ -289,10 +289,10 @@ char *check_in_cert_list(const char *canonical_domain_name)
 
     while(fgets(buf, OGS_HUGE_LEN, out)) {
 
-	ogs_debug("buf=\"%s\", canonical_domain_name=\"%s\"", buf, canonical_domain_name);
+        ogs_debug("buf=\"%s\", canonical_domain_name=\"%s\"", buf, canonical_domain_name);
         if (str_match(buf, canonical_domain_name)) {
             certificate = strtok_r(buf,"\t",&cert_id);
-	    ogs_debug("buf=\"%s\", certificate=\"%s\", cert_id=\"%s\"", buf, certificate, cert_id);
+            ogs_debug("buf=\"%s\", certificate=\"%s\", cert_id=\"%s\"", buf, certificate, cert_id);
             break;
         }
     }
@@ -326,28 +326,28 @@ static msaf_certificate_t *msaf_certificate_populate(const char *certid, const c
 
     line = cert;
     while ((eol = strchr(line, '\n')) != NULL) {
-	const char *end_field;
-	/* Stop when we get to the certificate, key or CSR */
+        const char *end_field;
+        /* Stop when we get to the certificate, key or CSR */
         if (strncmp(line, begin_marker, sizeof(begin_marker)-1) == 0)
-	    break;
+            break;
         /* otherwise try and interpret as "Field: Value" */
-	end_field = strchr(line, ':');
-	if (end_field) {
-	    char *field;
-	    char *value;
-	    const char *value_start;
-	    const char *value_end;
+        end_field = strchr(line, ':');
+        if (end_field) {
+            char *field;
+            char *value;
+            const char *value_start;
+            const char *value_end;
             field = ogs_strndup(line, end_field-line);
             value_start = end_field+1;
             while (*value_start && *value_start == ' ') value_start++;
-	    value_end = eol-1;
-	    while (value_end>value_start && *value_end == ' ') value_end--;
-	    value = ogs_strndup(value_start, value_end-value_start+1);
+            value_end = eol-1;
+            while (value_end>value_start && *value_end == ' ') value_end--;
+            value = ogs_strndup(value_start, value_end-value_start+1);
             nf_headers_set(msaf_certificate->headers, field, value);
-	    ogs_free(field);
-	    ogs_free(value);
-	}
-	line = eol+1;
+            ogs_free(field);
+            ogs_free(value);
+        }
+        line = eol+1;
     }
 
     msaf_certificate->certificate = msaf_strdup(line);

--- a/src/5gmsaf/consumption-report-configuration.c
+++ b/src/5gmsaf/consumption-report-configuration.c
@@ -1,0 +1,156 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: David Waring
+Copyright: (C) 2023 British Broadcasting Corporation
+
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+#include "ogs-core.h"
+
+#include "openapi/model/consumption_reporting_configuration.h"
+#include "provisioning-session.h"
+#include "hash.h"
+
+#include "consumption-report-configuration.h"
+
+bool msaf_consumption_report_configuration_register(msaf_provisioning_session_t *session /* [no-transfer, not-null] */,
+                                                  OpenAPI_consumption_reporting_configuration_t *config /* [transfer, not-null] */)
+{
+    char *body;
+
+    ogs_assert(session);
+    ogs_assert(config);
+
+    if (session->consumptionReportingConfiguration) return false;
+
+    session->consumptionReportingConfiguration = config;
+
+    body = msaf_consumption_report_configuration_body(session);
+    session->httpMetadata.consumptionReportingConfiguration.hash = calculate_hash(body);
+    ogs_free(body);
+
+    time(&session->httpMetadata.consumptionReportingConfiguration.received);
+
+    return true;
+}
+
+bool msaf_consumption_report_configuration_update(msaf_provisioning_session_t *session /* [no-transfer, not-null] */,
+                                                OpenAPI_consumption_reporting_configuration_t *config /* [transfer, not-null] */)
+{
+    char *body;
+
+    ogs_assert(session);
+    ogs_assert(config);
+
+    if (!session->consumptionReportingConfiguration) return false;
+
+    OpenAPI_consumption_reporting_configuration_free(session->consumptionReportingConfiguration);
+
+    if (session->httpMetadata.consumptionReportingConfiguration.hash) {
+        ogs_free(session->httpMetadata.consumptionReportingConfiguration.hash);
+    }
+
+    session->consumptionReportingConfiguration = config;
+
+    body = msaf_consumption_report_configuration_body(session);
+    session->httpMetadata.consumptionReportingConfiguration.hash = calculate_hash(body);
+    ogs_free(body);
+
+    time(&session->httpMetadata.consumptionReportingConfiguration.received);
+
+    return true;
+}
+
+bool msaf_consumption_report_configuration_deregister(msaf_provisioning_session_t *session /* [no-transfer, not-null] */)
+{
+    ogs_assert(session);
+
+    if (!session->consumptionReportingConfiguration) return false;
+
+    OpenAPI_consumption_reporting_configuration_free(session->consumptionReportingConfiguration);
+    session->consumptionReportingConfiguration = NULL;
+
+    if (session->httpMetadata.consumptionReportingConfiguration.hash) {
+        ogs_free(session->httpMetadata.consumptionReportingConfiguration.hash);
+        session->httpMetadata.consumptionReportingConfiguration.hash = NULL;
+    }
+    
+    session->httpMetadata.consumptionReportingConfiguration.received = 0;
+
+    return true;
+}
+
+cJSON *msaf_consumption_report_configuration_json(msaf_provisioning_session_t *session /* [no-transfer, not-null] */)
+{
+    cJSON *json;
+
+    ogs_assert(session);
+
+    if (!session->consumptionReportingConfiguration) return NULL;
+
+    json = OpenAPI_consumption_reporting_configuration_convertToJSON(session->consumptionReportingConfiguration);
+
+    if (!json) {
+        ogs_error("Failed to convert ConsumptionReportingConfiguration to JSON");
+    }
+
+    return json;
+}
+
+char *msaf_consumption_report_configuration_body(msaf_provisioning_session_t *session /* [no-transfer, not-null] */)
+{
+    cJSON *json;
+    char *body;
+    
+    ogs_assert(session);
+
+    if (!session->consumptionReportingConfiguration) return NULL;
+
+    json = msaf_consumption_report_configuration_json(session);
+    if (!json) return NULL;
+
+    body = cJSON_Print(json);
+
+    cJSON_Delete(json);
+
+    return body;
+}
+
+time_t msaf_consumption_report_configuration_last_modified(msaf_provisioning_session_t *session /* [no-transfer, not-null] */)
+{
+    ogs_assert(session);
+
+    return session->httpMetadata.consumptionReportingConfiguration.received;
+}
+
+char *msaf_consumption_report_configuration_etag(msaf_provisioning_session_t *session /* [no-transfer, not-null] */)
+{
+    ogs_assert(session);
+
+    return session->httpMetadata.consumptionReportingConfiguration.hash;
+}
+
+bool msaf_consumption_report_configuration_changed(msaf_provisioning_session_t *session /* [no-transfer, not-null] */,
+                                                   time_t modified_since, const char *none_match /* [null] */)
+{
+    ogs_assert(session);
+
+    /* Check modification time (input of 0 time indicates don't check modification time) */
+    if (modified_since != 0 && session->httpMetadata.consumptionReportingConfiguration.received != modified_since) {
+        return true;
+    }
+
+    /* Check ETag (NULL input means don't check ETag) */
+    if (none_match && (!session->httpMetadata.consumptionReportingConfiguration.hash ||
+                       strcmp(session->httpMetadata.consumptionReportingConfiguration.hash, none_match))) {
+        return true;
+    }
+
+    return false;
+}
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/5gmsaf/consumption-report-configuration.h
+++ b/src/5gmsaf/consumption-report-configuration.h
@@ -1,0 +1,43 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: David Waring
+Copyright: (C) 2023 British Broadcasting Corporation
+
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+#ifndef MSAF_CONSUMPTION_REPORT_CONFIGURATION_H
+#define MSAF_CONSUMPTION_REPORT_CONFIGURATION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct OpenAPI_consumption_reporting_configuration_s OpenAPI_consumption_reporting_configuration_t;
+typedef struct msaf_provisioning_session_s msaf_provisioning_session_t;
+
+extern bool msaf_consumption_report_configuration_register(msaf_provisioning_session_t *session /* [no-transfer, not-null] */,
+                                                OpenAPI_consumption_reporting_configuration_t *config /* [transfer, not-null] */);
+extern bool msaf_consumption_report_configuration_update(msaf_provisioning_session_t *session /* [no-transfer, not-null] */,
+                                                OpenAPI_consumption_reporting_configuration_t *config /* [transfer, not-null] */);
+extern bool msaf_consumption_report_configuration_deregister(msaf_provisioning_session_t *session /* [no-transfer, not-null] */);
+
+extern cJSON *msaf_consumption_report_configuration_json(msaf_provisioning_session_t *session /* [no-transfer, not-null] */);
+extern char *msaf_consumption_report_configuration_body(msaf_provisioning_session_t *session /* [no-transfer, not-null] */);
+extern time_t msaf_consumption_report_configuration_last_modified(
+                                        msaf_provisioning_session_t *session /* [no-transfer, not-null] */);
+extern char *msaf_consumption_report_configuration_etag(msaf_provisioning_session_t *session /* [no-transfer, not-null] */);
+
+extern bool msaf_consumption_report_configuration_changed(msaf_provisioning_session_t *session /* [no-transfer, not-null] */,
+                                                          time_t modified_since, const char *none_match /* [null] */);
+
+#ifdef __cplusplus
+}
+#endif
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+
+#endif /* MSAF_CONSUMPTION_REPORT_CONFIGURATION_H */

--- a/src/5gmsaf/context.c
+++ b/src/5gmsaf/context.c
@@ -200,6 +200,7 @@ int msaf_context_parse_config(void)
                     int m1_content_hosting_configurations_response_max_age = SERVER_RESPONSE_MAX_AGE;
                     int m1_server_certificates_response_max_age = SERVER_RESPONSE_MAX_AGE;
 	            int m1_content_protocols_response_max_age = M1_CONTENT_PROTOCOLS_RESPONSE_MAX_AGE;
+                    int m1_consumption_reporting_response_max_age = SERVER_RESPONSE_MAX_AGE;
 	            int m5_service_access_information_response_max_age = SERVER_RESPONSE_MAX_AGE;
                     while (ogs_yaml_iter_next(&cc_iter)) {
                         const char *cc_key = ogs_yaml_iter_key(&cc_iter);
@@ -212,11 +213,16 @@ int msaf_context_parse_config(void)
                             m1_content_hosting_configurations_response_max_age = ascii_to_long(ogs_yaml_iter_value(&cc_iter));
                         } else if (!strcmp(cc_key, "m1ContentProtocols")) {
                             m1_content_protocols_response_max_age = ascii_to_long(ogs_yaml_iter_value(&cc_iter));
+                        } else if (!strcmp(cc_key, "m1ConsumptionReportingConfiguration")) {
+                            m1_consumption_reporting_response_max_age = ascii_to_long(ogs_yaml_iter_value(&cc_iter));
                         } else if (!strcmp(cc_key, "m5ServiceAccessInformation")) {
                             m5_service_access_information_response_max_age = ascii_to_long(ogs_yaml_iter_value(&cc_iter));
                         }
                     }
-		            msaf_server_response_cache_control_set_from_config(m1_provisioning_session_response_max_age,  m1_content_hosting_configurations_response_max_age, m1_server_certificates_response_max_age, m1_content_protocols_response_max_age, m5_service_access_information_response_max_age);
+		    msaf_server_response_cache_control_set_from_config(
+                                m1_provisioning_session_response_max_age, m1_content_hosting_configurations_response_max_age,
+                                m1_server_certificates_response_max_age, m1_content_protocols_response_max_age,
+                                m1_consumption_reporting_response_max_age, m5_service_access_information_response_max_age);
  
                 }  else if (!strcmp(msaf_key, "sbi") || !strcmp(msaf_key, "m1") || !strcmp(msaf_key, "m5") || !strcmp(msaf_key, "maf")) {
                     if(!self->config.open5gsIntegration_flag) {
@@ -682,13 +688,13 @@ msaf_context_provisioning_session_free(msaf_provisioning_session_t *provisioning
     if (provisioning_session->provisioningSessionId) ogs_free(provisioning_session->provisioningSessionId);
     if (provisioning_session->aspId) ogs_free(provisioning_session->aspId);
     if (provisioning_session->externalApplicationId) ogs_free(provisioning_session->externalApplicationId);
-    if (provisioning_session->provisioningSessionHash) ogs_free(provisioning_session->provisioningSessionHash);
+    if (provisioning_session->httpMetadata.provisioningSession.hash) ogs_free(provisioning_session->httpMetadata.provisioningSession.hash);
 
     if (provisioning_session->contentHostingConfiguration) OpenAPI_content_hosting_configuration_free(provisioning_session->contentHostingConfiguration);
-    if (provisioning_session->contentHostingConfigurationHash) ogs_free(provisioning_session->contentHostingConfigurationHash);
+    if (provisioning_session->httpMetadata.contentHostingConfiguration.hash) ogs_free(provisioning_session->httpMetadata.contentHostingConfiguration.hash);
 
     if (provisioning_session->serviceAccessInformation) OpenAPI_service_access_information_resource_free(provisioning_session->serviceAccessInformation);
-    if (provisioning_session->serviceAccessInformationHash) ogs_free(provisioning_session->serviceAccessInformationHash);
+    if (provisioning_session->httpMetadata.serviceAccessInformation.hash) ogs_free(provisioning_session->httpMetadata.serviceAccessInformation.hash);
     
     ogs_list_for_each_safe(&provisioning_session->application_server_states, next_as_state_ref, as_state_ref) {
         ogs_list_remove(&provisioning_session->application_server_states, as_state_ref);

--- a/src/5gmsaf/context.c
+++ b/src/5gmsaf/context.c
@@ -91,7 +91,7 @@ void msaf_context_final(void)
 
     if (self->config.server_response_cache_control)
     {
-        ogs_free(self->config.server_response_cache_control);	    
+        ogs_free(self->config.server_response_cache_control);    
     }
  
     if (self->config.certificateManager)
@@ -199,9 +199,9 @@ int msaf_context_parse_config(void)
                     int m1_provisioning_session_response_max_age = SERVER_RESPONSE_MAX_AGE;
                     int m1_content_hosting_configurations_response_max_age = SERVER_RESPONSE_MAX_AGE;
                     int m1_server_certificates_response_max_age = SERVER_RESPONSE_MAX_AGE;
-	            int m1_content_protocols_response_max_age = M1_CONTENT_PROTOCOLS_RESPONSE_MAX_AGE;
+                    int m1_content_protocols_response_max_age = M1_CONTENT_PROTOCOLS_RESPONSE_MAX_AGE;
                     int m1_consumption_reporting_response_max_age = SERVER_RESPONSE_MAX_AGE;
-	            int m5_service_access_information_response_max_age = SERVER_RESPONSE_MAX_AGE;
+                    int m5_service_access_information_response_max_age = SERVER_RESPONSE_MAX_AGE;
                     while (ogs_yaml_iter_next(&cc_iter)) {
                         const char *cc_key = ogs_yaml_iter_key(&cc_iter);
                         ogs_assert(cc_key);
@@ -219,7 +219,7 @@ int msaf_context_parse_config(void)
                             m5_service_access_information_response_max_age = ascii_to_long(ogs_yaml_iter_value(&cc_iter));
                         }
                     }
-		    msaf_server_response_cache_control_set_from_config(
+                    msaf_server_response_cache_control_set_from_config(
                                 m1_provisioning_session_response_max_age, m1_content_hosting_configurations_response_max_age,
                                 m1_server_certificates_response_max_age, m1_content_protocols_response_max_age,
                                 m1_consumption_reporting_response_max_age, m5_service_access_information_response_max_age);
@@ -521,15 +521,15 @@ static void msaf_context_server_addr_remove_all()
 {
     msaf_context_server_addr_t *msaf_server_addr = NULL, *next = NULL;
     ogs_list_for_each_safe(&msaf_self()->config.server_addr_list, next, msaf_server_addr)
-        msaf_context_server_addr_remove(msaf_server_addr);
+    msaf_context_server_addr_remove(msaf_server_addr);
 
 }
 
 static void msaf_context_server_addr_remove(msaf_context_server_addr_t *msaf_server_addr)
 {
-        ogs_assert(msaf_server_addr);
-	ogs_list_remove(&msaf_self()->config.server_addr_list, msaf_server_addr);
-	ogs_free(msaf_server_addr);
+    ogs_assert(msaf_server_addr);
+    ogs_list_remove(&msaf_self()->config.server_addr_list, msaf_server_addr);
+    ogs_free(msaf_server_addr);
 }
 
 static void msaf_context_application_server_state_certificates_remove_all(void) {

--- a/src/5gmsaf/generator-5gmsaf
+++ b/src/5gmsaf/generator-5gmsaf
@@ -29,7 +29,7 @@ scriptdir=`cd "$scriptdir"; pwd`
 
 # Command line option defaults
 default_branch='REL-17'
-default_apis="TS26512_M1_ProvisioningSessions TS26512_M1_ContentHostingProvisioning TS26512_M1_ServerCertificatesProvisioning TS26512_M1_ContentProtocolsDiscovery M3_ContentHostingProvisioning M3_ServerCertificatesProvisioning TS26512_M5_ServiceAccessInformation Maf_Management"
+default_apis="TS26512_M1_ProvisioningSessions TS26512_M1_ContentHostingProvisioning TS26512_M1_ServerCertificatesProvisioning TS26512_M1_ContentProtocolsDiscovery TS26512_M1_ConsumptionReportingProvisioning M3_ContentHostingProvisioning M3_ServerCertificatesProvisioning TS26512_M5_ServiceAccessInformation Maf_Management"
 
 # Parse command line arguments
 ARGS=`getopt -n "$scriptname" -o 'a:b:hM:' -l 'api:,branch:,help,model-deps:' -s sh -- "$@"`

--- a/src/5gmsaf/init.c
+++ b/src/5gmsaf/init.c
@@ -39,8 +39,8 @@ int msaf_initialize()
     }
 
     if (!msaf_distribution_certificate_check()) {
-	ogs_error("Consistency checks failed, aborting");
-	return OGS_ERROR;
+        ogs_error("Consistency checks failed, aborting");
+        return OGS_ERROR;
     }
 
     rv = ogs_log_config_domain(ogs_app()->logger.domain, ogs_app()->logger.level);
@@ -132,14 +132,17 @@ static int msaf_set_time(void)
     if(ogs_env_set("TZ", "GMT") != OGS_OK)
     {
         ogs_error("Failed to set TZ to GMT");
-	return OGS_ERROR;
+        return OGS_ERROR;
     }
 
     if(ogs_env_set("LC_TIME", "C") != OGS_OK)
     {
         ogs_error("Failed to set LC_TIME to C");
-	return OGS_ERROR;
+        return OGS_ERROR;
     }
     return OGS_OK;
 
 }
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/5gmsaf/meson.build
+++ b/src/5gmsaf/meson.build
@@ -57,8 +57,10 @@ libmsaf_dist_sources = files('''
     msaf-m5-sm.c
     utilities.h
     utilities.c
-    init.c
     init.h
+    init.c
+    consumption-report-configuration.c
+    consumption-report-configuration.h
 '''.split())
 
 api_tag = latest_apis?'REL-'+fiveg_api_release:'TSG'+fiveg_api_approval+'-Rel'+fiveg_api_release

--- a/src/5gmsaf/msaf-fsm.h
+++ b/src/5gmsaf/msaf-fsm.h
@@ -25,7 +25,6 @@ typedef struct msaf_fsm_s {
 
 extern void msaf_fsm_init(void);
 extern void msaf_fsm_fini(void);
-	
 
 #ifdef __cplusplus
 }

--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -19,10 +19,12 @@
 #include "msaf-version.h"
 #include "msaf-sm.h"
 #include "utilities.h"
+#include "consumption-report-configuration.h"
 #include "ContentProtocolsDiscovery_body.h"
 #include "openapi/api/TS26512_M1_ProvisioningSessionsAPI-info.h"
 #include "openapi/api/TS26512_M1_ServerCertificatesProvisioningAPI-info.h"
 #include "openapi/api/TS26512_M1_ContentHostingProvisioningAPI-info.h"
+#include "openapi/api/TS26512_M1_ConsumptionReportingProvisioningAPI-info.h"
 #include "openapi/api/M3_ServerCertificatesProvisioningAPI-info.h"
 #include "openapi/api/M3_ContentHostingProvisioningAPI-info.h"
 #include "openapi/api/TS26512_M1_ContentProtocolsDiscoveryAPI-info.h"
@@ -50,6 +52,12 @@ const nf_server_interface_metadata_t
 m1_servercertificatesprovisioning_api_metadata = {
     M1_SERVERCERTIFICATESPROVISIONING_API_NAME,
     M1_SERVERCERTIFICATESPROVISIONING_API_VERSION
+};
+
+const nf_server_interface_metadata_t
+m1_consumptionreportingprovisioning_api_metadata = {
+    M1_CONSUMPTIONREPORTINGPROVISIONING_API_NAME,
+    M1_CONSUMPTIONREPORTINGPROVISIONING_API_VERSION
 };
 
 const nf_server_interface_metadata_t
@@ -95,6 +103,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
     const nf_server_interface_metadata_t *m1_contenthostingprovisioning_api = &m1_contenthostingprovisioning_api_metadata;
     const nf_server_interface_metadata_t *m1_contentprotocolsdiscovery_api = &m1_contentprotocolsdiscovery_api_metadata;
     const nf_server_interface_metadata_t *m1_servercertificatesprovisioning_api = &m1_servercertificatesprovisioning_api_metadata;
+    const nf_server_interface_metadata_t *m1_consumptionreportingprovisioning_api = &m1_consumptionreportingprovisioning_api_metadata;
     const nf_server_interface_metadata_t *m3_contenthostingprovisioning_api = &m3_contenthostingprovisioning_api_metatdata;
     const nf_server_interface_metadata_t *maf_management_api = &maf_management_api_metadata;
     const nf_server_app_metadata_t *app_meta = &app_metadata;
@@ -234,108 +243,124 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                         } else if (message->h.resource.component[1] && message->h.resource.component[2] &&
                                    !message->h.resource.component[3]) {
                             msaf_provisioning_session_t *msaf_provisioning_session;
-                            if (!strcmp(message->h.resource.component[2], "content-hosting-configuration")) {
-                                msaf_provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(
-                                        message->h.resource.component[1]);
-                                if (msaf_provisioning_session) {
-                                    // process the POST body
-                                    int rv;
-                                    cJSON *chc;
-                                    cJSON *content_hosting_config;
+                            const nf_server_interface_metadata_t *api = NULL;
 
-                                    ogs_debug("Request body: %s", request->http.content);
+                            SWITCH(message->h.resource.component[2])
+                            CASE("consumption-reporting-configuration")
+                                api = m1_consumptionreportingprovisioning_api;
+                                break;
+                            CASE("content-hosting-configuration")
+                                api = m1_contenthostingprovisioning_api;
+                                break;
+                            CASE("certificates")
+                                api = m1_servercertificatesprovisioning_api;
+                                break;
+                            DEFAULT
+                            END
 
-                                    content_hosting_config = cJSON_Parse(request->http.content);
-                                    {
-                                        char *txt = cJSON_Print(content_hosting_config);
-                                        ogs_debug("Parsed JSON: %s", txt);
-                                        cJSON_free(txt);
+                            msaf_provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(message->h.resource.component[1]);
+                            if (!msaf_provisioning_session) {
+                                char *err = NULL;
+                                err = ogs_msprintf("Provisioning session [%s] does not exist.", message->h.resource.component[1]);
+                                ogs_error("%s", err);
+                                ogs_assert(true == nf_server_send_error(stream, 404, 3, message, "Provisioning session does not exist.", err, NULL, api, app_meta));
+                                ogs_free(err);
+                            } else if (!api) {
+                                char *err = NULL;
+                                err = ogs_msprintf("Unknown sub resource [%s] for provisioning session [%s]", message->h.resource.component[2], message->h.resource.component[1]);
+                                ogs_error("%s", err);
+                                ogs_assert(true == nf_server_send_error(stream, 404, 3, message, "Provisioning session does not exist.", err, NULL, m1_provisioningsession_api, app_meta));
+                                ogs_free(err);
+                            } else if (api == m1_contenthostingprovisioning_api) {
+                                // process the POST body
+                                int rv;
+                                cJSON *chc;
+                                cJSON *content_hosting_config;
+
+                                ogs_debug("Request body: %s", request->http.content);
+
+                                content_hosting_config = cJSON_Parse(request->http.content);
+                                {
+                                    char *txt = cJSON_Print(content_hosting_config);
+                                    ogs_debug("Parsed JSON: %s", txt);
+                                    cJSON_free(txt);
+                                }
+
+                                if (!content_hosting_config) {
+                                    char *err = NULL;
+                                    err = ogs_msprintf("Unable to parse Content Hosting Configuration as JSON for the Provisioning Session [%s].", message->h.resource.component[1]);
+                                    ogs_error("%s", err);
+                                    ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Bad Content Hosting Configuration.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
+                                    ogs_free(err);
+                                } else {
+                                    if(msaf_provisioning_session->contentHostingConfiguration) {
+                                        OpenAPI_content_hosting_configuration_free(
+                                                msaf_provisioning_session->contentHostingConfiguration);
+                                        msaf_provisioning_session->contentHostingConfiguration = NULL;
                                     }
 
-                                    if (!content_hosting_config) {
-                                        char *err = NULL;
-                                        err = ogs_msprintf("Unable to parse Content Hosting Configuration as JSON for the Provisioning Session [%s].", message->h.resource.component[1]);
-                                        ogs_error("%s", err);
-                                        ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Bad Content Hosting Configuration.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
-                                        ogs_free(err);
-                                    } else {
-
-                                        if(msaf_provisioning_session->contentHostingConfiguration) {
-                                            OpenAPI_content_hosting_configuration_free(
-                                                    msaf_provisioning_session->contentHostingConfiguration);
-                                            msaf_provisioning_session->contentHostingConfiguration = NULL;
-                                        }
+                                    if (msaf_provisioning_session->serviceAccessInformation) {
+                                        OpenAPI_service_access_information_resource_free(
+                                                msaf_provisioning_session->serviceAccessInformation);
+                                        msaf_provisioning_session->serviceAccessInformation = NULL;
+                                    }
     
-                                        if (msaf_provisioning_session->serviceAccessInformation) {
-                                            OpenAPI_service_access_information_resource_free(
-                                                    msaf_provisioning_session->serviceAccessInformation);
-                                            msaf_provisioning_session->serviceAccessInformation = NULL;
-                                        }
+                                    rv = msaf_distribution_create(content_hosting_config, msaf_provisioning_session);
+                                    content_hosting_config = NULL;
     
-                                        rv = msaf_distribution_create(content_hosting_config, msaf_provisioning_session);
-                                        content_hosting_config = NULL;
+                                    if(rv){
     
-                                        if(rv){
-    
-                                            ogs_debug("Content Hosting Configuration created successfully");
-                                            if (msaf_application_server_state_set_on_post(msaf_provisioning_session)) {
-                                                chc = msaf_get_content_hosting_configuration_by_provisioning_session_id(
-                                                        message->h.resource.component[1]);
-                                                if (chc != NULL) {
-                                                    char *text;
-                                                    msaf_provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(
+                                        ogs_debug("Content Hosting Configuration created successfully");
+                                        if (msaf_application_server_state_set_on_post(msaf_provisioning_session)) {
+                                            chc = msaf_get_content_hosting_configuration_by_provisioning_session_id(
+                                                    message->h.resource.component[1]);
+                                            if (chc != NULL) {
+                                                char *text;
+                                                msaf_provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(
                                                             message->h.resource.component[1]);
-                                                    response = nf_server_new_response(request->h.uri, "application/json",
-                                                            msaf_provisioning_session->contentHostingConfigurationReceived,
-                                                            msaf_provisioning_session->contentHostingConfigurationHash,
+                                                response = nf_server_new_response(request->h.uri, "application/json",
+                                                            msaf_provisioning_session->httpMetadata.contentHostingConfiguration.received,
+                                                            msaf_provisioning_session->httpMetadata.contentHostingConfiguration.hash,
                                                             msaf_self()->config.server_response_cache_control->m1_content_hosting_configurations_response_max_age,
                                                             NULL, m1_contenthostingprovisioning_api, app_meta);
-                                                    ogs_assert(response);
-                                                    text = cJSON_Print(chc);
-                                                    nf_server_populate_response(response, strlen(text), text, 201);
-                                                    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
-                                                    response = NULL;
-                                                    cJSON_Delete(chc);
-                                                } else {
-                                                    char *err = NULL;
-                                                    err = ogs_msprintf("Unable to retrieve the Content Hosting Configuration for the Provisioning Session [%s].", message->h.resource.component[1]);
-                                                    ogs_error("%s", err);
-                                                    ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Unable to retrieve the Content Hosting Configuration.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
-                                                    ogs_free(err);
-                                                }
+                                                ogs_assert(response);
+                                                text = cJSON_Print(chc);
+                                                nf_server_populate_response(response, strlen(text), text, 201);
+                                                ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+                                                response = NULL;
+                                                cJSON_Delete(chc);
                                             } else {
                                                 char *err = NULL;
-                                                err = ogs_msprintf("Verification error on Content Hosting Configuration for the Provisioning Session [%s].", message->h.resource.component[1]);
+                                                err = ogs_msprintf("Unable to retrieve the Content Hosting Configuration for the Provisioning Session [%s].", message->h.resource.component[1]);
                                                 ogs_error("%s", err);
-                                                ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Bad Content Hosting Configuration.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
+                                                ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Unable to retrieve the Content Hosting Configuration.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
                                                 ogs_free(err);
                                             }
                                         } else {
                                             char *err = NULL;
-                                            err = ogs_msprintf("Creation of the Content Hosting Configuration failed for the Provisioning Session [%s]", message->h.resource.component[1]);
+                                            err = ogs_msprintf("Verification error on Content Hosting Configuration for the Provisioning Session [%s].", message->h.resource.component[1]);
                                             ogs_error("%s", err);
-                                            ogs_assert(true == nf_server_send_error(stream, 500, 2, message, "Creation of the Content Hosting Configuration failed.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
+                                            ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Bad Content Hosting Configuration.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
                                             ogs_free(err);
                                         }
+                                    } else {
+                                        char *err = NULL;
+                                        err = ogs_msprintf("Creation of the Content Hosting Configuration failed for the Provisioning Session [%s]", message->h.resource.component[1]);
+                                        ogs_error("%s", err);
+                                        ogs_assert(true == nf_server_send_error(stream, 500, 2, message, "Creation of the Content Hosting Configuration failed.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
+                                        ogs_free(err);
                                     }
 
                                     if (content_hosting_config) cJSON_Delete(content_hosting_config);
-
-                                } else {
-                                    char *err = NULL;
-                                    err = ogs_msprintf("Provisioning session [%s]does not exist.", message->h.resource.component[1]);
-                                    ogs_error("%s",err);
-                                    ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Provisioning session does not exist.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
-                                    ogs_free(err);
                                 }
 
-                            }
-                            if (!strcmp(message->h.resource.component[2],"certificates")) {
+                            } else if (api == m1_servercertificatesprovisioning_api) {
                                 ogs_info("POST certificates");
                                 ogs_hash_index_t *hi;
                                 char *canonical_domain_name;
                                 char *cert;
                                 int csr = 0;
+                                msaf_application_server_node_t *msaf_as = NULL;
 
                                 for (hi = ogs_hash_first(request->http.params);
                                         hi; hi = ogs_hash_next(hi)) {
@@ -345,28 +370,37 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                     }
                                 }
 
-                                msaf_provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(message->h.resource.component[1]);
-                                if (msaf_provisioning_session) {
-                                    msaf_application_server_node_t *msaf_as = NULL;
-                                    msaf_as = ogs_list_first(&msaf_self()->config.applicationServers_list);
-                                    canonical_domain_name = msaf_as->canonicalHostname;
-                                    ogs_info("canonical_domain_name: %s", canonical_domain_name);
+                                msaf_as = ogs_list_first(&msaf_self()->config.applicationServers_list);
+                                canonical_domain_name = msaf_as->canonicalHostname;
+                                ogs_info("canonical_domain_name: %s", canonical_domain_name);
 
-                                    if (csr) {
-                                        msaf_certificate_t *csr_cert;
-                                        char *location;
-                                        int m1_server_certificates_response_max_age;
-                                        ogs_list_t extra_domains_list;
-                                        fqdn_list_node_t *node, *next;
+                                if (csr) {
+                                    msaf_certificate_t *csr_cert;
+                                    char *location;
+                                    int m1_server_certificates_response_max_age;
+                                    ogs_list_t extra_domains_list;
+                                    fqdn_list_node_t *node, *next;
 
-                                        ogs_list_init(&extra_domains_list);
+                                    ogs_list_init(&extra_domains_list);
 
-                                        if (request->http.content && strlen(request->http.content) > 0) {
-                                            cJSON *json;
-                                            cJSON *fqdn_json;
-                                            json = cJSON_Parse(request->http.content);
+                                    if (request->http.content && strlen(request->http.content) > 0) {
+                                        cJSON *json;
+                                        cJSON *fqdn_json;
+                                        json = cJSON_Parse(request->http.content);
 
-                                            if (!json || !cJSON_IsArray(json)) {
+                                        if (!json || !cJSON_IsArray(json)) {
+                                            char *err;
+                                            err = msaf_strdup("Body does not contain a valid JSON array.");
+                                            ogs_error("%s", err);
+                                            ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Invalid content", err, NULL, m1_servercertificatesprovisioning_api, app_meta));
+                                            ogs_free(err);
+                                            if (json) cJSON_Delete(json);
+                                            break;
+                                        }
+
+                                        cJSON_ArrayForEach(fqdn_json, json) {
+                                            char *fqdn;
+                                            if (!cJSON_IsString(fqdn_json)) {
                                                 char *err;
                                                 err = msaf_strdup("Body does not contain a valid JSON array.");
                                                 ogs_error("%s", err);
@@ -375,95 +409,115 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                                 if (json) cJSON_Delete(json);
                                                 break;
                                             }
-
-                                            cJSON_ArrayForEach(fqdn_json, json) {
-                                                char *fqdn;
-                                                if (!cJSON_IsString(fqdn_json)) {
-                                                    char *err;
-                                                    err = msaf_strdup("Body does not contain a valid JSON array.");
-                                                    ogs_error("%s", err);
-                                                    ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Invalid content", err, NULL, m1_servercertificatesprovisioning_api, app_meta));
-                                                    ogs_free(err);
-                                                    if (json) cJSON_Delete(json);
-                                                    break;
-                                                }
-                                                fqdn = msaf_strdup(cJSON_GetStringValue(fqdn_json));
-                                                node = ogs_calloc(1,sizeof(*node));
-                                                node->fqdn = fqdn;
-                                                ogs_list_add(&extra_domains_list, &node->node);
-                                            }
-
-                                            cJSON_Delete(json);
+                                            fqdn = msaf_strdup(cJSON_GetStringValue(fqdn_json));
+                                            node = ogs_calloc(1,sizeof(*node));
+                                            node->fqdn = fqdn;
+                                            ogs_list_add(&extra_domains_list, &node->node);
                                         }
-
-                                        csr_cert = server_cert_new("newcsr", canonical_domain_name, &extra_domains_list);
-
-                                        ogs_list_for_each_safe(&extra_domains_list, next, node) {
-                                            ogs_free(node->fqdn);
-                                            ogs_list_remove(&extra_domains_list, node);
-                                            ogs_free(node);
-                                        }
-
-                                        ogs_hash_set(msaf_provisioning_session->certificate_map, msaf_strdup(csr_cert->id), OGS_HASH_KEY_STRING, msaf_strdup(csr_cert->id));
-                                        ogs_sbi_response_t *response;
-                                        location = ogs_msprintf("%s/%s", request->h.uri, csr_cert->id);
-                                        if(csr_cert->cache_control_max_age){
-                                            m1_server_certificates_response_max_age = csr_cert->cache_control_max_age;
-                                        } else {
-                                            m1_server_certificates_response_max_age = msaf_self()->config.server_response_cache_control->m1_server_certificates_response_max_age;
-                                        }
-                                        response = nf_server_new_response(location, "application/x-pem-file",  csr_cert->last_modified, csr_cert->server_certificate_hash, m1_server_certificates_response_max_age, NULL, m1_servercertificatesprovisioning_api, app_meta);
-
-                                        nf_server_populate_response(response, strlen(csr_cert->certificate), msaf_strdup(csr_cert->certificate), 200);
-
-                                        ogs_assert(response);
-                                        ogs_assert(true == ogs_sbi_server_send_response(stream, response));
-                                        ogs_free(location);
-                                        msaf_certificate_free(csr_cert);
-
-                                        break;
+                                        cJSON_Delete(json);
                                     }
 
-                                    cert = check_in_cert_list(canonical_domain_name);
-                                    if (cert != NULL) {
-                                        ogs_sbi_response_t *response;
-                                        char *location;
+                                    csr_cert = server_cert_new("newcsr", canonical_domain_name, &extra_domains_list);
 
-                                        ogs_hash_set(msaf_provisioning_session->certificate_map, msaf_strdup(cert), OGS_HASH_KEY_STRING, cert);
-                                        
-                                        location = ogs_msprintf("%s/%s", request->h.uri, cert);
-                                        response = nf_server_new_response(location, NULL,  0, NULL, 0, NULL, m1_servercertificatesprovisioning_api, app_meta);
-                                        nf_server_populate_response(response, 0, NULL, 200);
-                                        ogs_assert(response);
-                                        ogs_assert(true == ogs_sbi_server_send_response(stream, response));
-                                        ogs_free(location);
+                                    ogs_list_for_each_safe(&extra_domains_list, next, node) {
+                                        ogs_free(node->fqdn);
+                                        ogs_list_remove(&extra_domains_list, node);
+                                        ogs_free(node);
+                                    }
+
+                                    ogs_hash_set(msaf_provisioning_session->certificate_map, msaf_strdup(csr_cert->id), OGS_HASH_KEY_STRING, msaf_strdup(csr_cert->id));
+                                    ogs_sbi_response_t *response;
+                                    location = ogs_msprintf("%s/%s", request->h.uri, csr_cert->id);
+                                    if(csr_cert->cache_control_max_age){
+                                        m1_server_certificates_response_max_age = csr_cert->cache_control_max_age;
                                     } else {
-                                        msaf_certificate_t *new_cert;
-                                        int m1_server_certificates_response_max_age;
-                                        ogs_sbi_response_t *response;
-                                        char *location;
-                                        new_cert = server_cert_new("newcert", canonical_domain_name, NULL);
-                                        ogs_hash_set(msaf_provisioning_session->certificate_map, msaf_strdup(new_cert->id), OGS_HASH_KEY_STRING, msaf_strdup(new_cert->id));
-                                     
-                                        location = ogs_msprintf("%s/%s", request->h.uri, new_cert->id);
-                                        if(new_cert->cache_control_max_age){
-                                            m1_server_certificates_response_max_age = new_cert->cache_control_max_age;
-                                        } else {
-                                            m1_server_certificates_response_max_age = msaf_self()->config.server_response_cache_control->m1_server_certificates_response_max_age;
-                                        }
-                                        response = nf_server_new_response(location, NULL,  new_cert->last_modified, new_cert->server_certificate_hash, m1_server_certificates_response_max_age, NULL, m1_servercertificatesprovisioning_api, app_meta);
-                                        nf_server_populate_response(response, 0, NULL, 200);
-                                        ogs_assert(response);
-                                        ogs_assert(true == ogs_sbi_server_send_response(stream, response));
-                                        ogs_free(location);
-                                        msaf_certificate_free(new_cert);
+                                        m1_server_certificates_response_max_age = msaf_self()->config.server_response_cache_control->m1_server_certificates_response_max_age;
                                     }
+                                    response = nf_server_new_response(location, "application/x-pem-file",  csr_cert->last_modified, csr_cert->server_certificate_hash, m1_server_certificates_response_max_age, NULL, m1_servercertificatesprovisioning_api, app_meta);
+
+                                    nf_server_populate_response(response, strlen(csr_cert->certificate), msaf_strdup(csr_cert->certificate), 200);
+
+                                    ogs_assert(response);
+                                    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+                                    ogs_free(location);
+                                    msaf_certificate_free(csr_cert);
+
+                                    break;
+                                }
+
+                                cert = check_in_cert_list(canonical_domain_name);
+                                if (cert != NULL) {
+                                    ogs_sbi_response_t *response;
+                                    char *location;
+
+                                    ogs_hash_set(msaf_provisioning_session->certificate_map, msaf_strdup(cert), OGS_HASH_KEY_STRING, cert);
+                                        
+                                    location = ogs_msprintf("%s/%s", request->h.uri, cert);
+                                    response = nf_server_new_response(location, NULL,  0, NULL, 0, NULL, m1_servercertificatesprovisioning_api, app_meta);
+                                    nf_server_populate_response(response, 0, NULL, 200);
+                                    ogs_assert(response);
+                                    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+                                    ogs_free(location);
                                 } else {
-                                    char *err = NULL;
-                                    err = ogs_msprintf("Provisioning session [%s] does not exists.", message->h.resource.component[1]);
+                                    msaf_certificate_t *new_cert;
+                                    int m1_server_certificates_response_max_age;
+                                    ogs_sbi_response_t *response;
+                                    char *location;
+                                    new_cert = server_cert_new("newcert", canonical_domain_name, NULL);
+                                    ogs_hash_set(msaf_provisioning_session->certificate_map, msaf_strdup(new_cert->id), OGS_HASH_KEY_STRING, msaf_strdup(new_cert->id));
+                                     
+                                    location = ogs_msprintf("%s/%s", request->h.uri, new_cert->id);
+                                    if(new_cert->cache_control_max_age){
+                                        m1_server_certificates_response_max_age = new_cert->cache_control_max_age;
+                                    } else {
+                                        m1_server_certificates_response_max_age = msaf_self()->config.server_response_cache_control->m1_server_certificates_response_max_age;
+                                    }
+                                    response = nf_server_new_response(location, NULL,  new_cert->last_modified, new_cert->server_certificate_hash, m1_server_certificates_response_max_age, NULL, m1_servercertificatesprovisioning_api, app_meta);
+                                    nf_server_populate_response(response, 0, NULL, 200);
+                                    ogs_assert(response);
+                                    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+                                    ogs_free(location);
+                                    msaf_certificate_free(new_cert);
+                                }
+                            } else if (api == m1_consumptionreportingprovisioning_api) {
+                                cJSON *json;
+
+                                ogs_debug("POST consumption-reporting-configuration");
+
+                                json = cJSON_Parse(request->http.content);
+                                if (!json) {
+                                    char *err;
+                                    err = ogs_msprintf("Bad ConsumptionReportingConfiguration for provisioning session [%s]", message->h.resource.component[1]);
                                     ogs_error("%s", err);
-                                    ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Provisioning session does not exists.", err, NULL, m1_servercertificatesprovisioning_api, app_meta));
+                                    ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Bad request.", err, NULL, api, app_meta));
                                     ogs_free(err);
+                                } else {
+                                    OpenAPI_consumption_reporting_configuration_t *report_config;
+
+                                    report_config = OpenAPI_consumption_reporting_configuration_parseFromJSON(json);
+                                    cJSON_Delete(json);
+
+                                    if (!report_config) {
+                                        char *err;
+                                        err = ogs_msprintf("Bad ConsumptionReportingConfiguration for provisioning session [%s]", message->h.resource.component[1]);
+                                        ogs_error("%s", err);
+                                        ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Bad request.", err, NULL, api, app_meta));
+                                        ogs_free(err);
+                                    } else if (!msaf_consumption_report_configuration_register(msaf_provisioning_session, report_config)) {
+                                        char *err;
+                                        err = ogs_msprintf("Unable to register ConsumptionReportingConfiguration for provisioning session [%s]", message->h.resource.component[1]);
+                                        ogs_error("%s", err);
+                                        ogs_assert(true == nf_server_send_error(stream, 408, 2, message, "Already a ConsumptionReportingConfiguration registered.", err, NULL, api, app_meta));
+                                        ogs_free(err);
+                                        OpenAPI_consumption_reporting_configuration_free(report_config);
+                                    } else {
+                                        ogs_sbi_response_t *response;
+    
+                                        response = nf_server_new_response(NULL, NULL,  0, NULL, 0, NULL, api, app_meta);
+                                        ogs_assert(response);
+                                        nf_server_populate_response(response, 0, NULL, 204);
+                                        ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+                                    }
                                 }
                             }
 
@@ -554,7 +608,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                 } else {
                                     location = ogs_msprintf("%s%s", request->h.uri,msaf_provisioning_session->provisioningSessionId);
                                 }
-                                response = nf_server_new_response(location, "application/json",  msaf_provisioning_session->provisioningSessionReceived, msaf_provisioning_session->provisioningSessionHash, msaf_self()->config.server_response_cache_control->m1_provisioning_session_response_max_age, NULL, m1_provisioningsession_api, app_meta);
+                                response = nf_server_new_response(location, "application/json",  msaf_provisioning_session->httpMetadata.provisioningSession.received, msaf_provisioning_session->httpMetadata.provisioningSession.hash, msaf_self()->config.server_response_cache_control->m1_provisioning_session_response_max_age, NULL, m1_provisioningsession_api, app_meta);
 
                                 nf_server_populate_response(response, strlen(text), text, 201);
                                 ogs_assert(response);
@@ -641,53 +695,85 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                             }
                         } else if (message->h.resource.component[1] && message->h.resource.component[2] && !message->h.resource.component[3]) {
                             msaf_provisioning_session_t *msaf_provisioning_session;
+                            const nf_server_interface_metadata_t *api = NULL;
+
+                            SWITCH(message->h.resource.component[2])
+                            CASE("consumption-reporting-configuration")
+                                api = m1_consumptionreportingprovisioning_api;
+                                break;
+                            CASE("content-hosting-configuration")
+                                api = m1_contenthostingprovisioning_api;
+                                break;
+                            CASE("protocols")
+                                api = m1_contentprotocolsdiscovery_api;
+                                break;
+                            DEFAULT
+                            END
+
                             msaf_provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(message->h.resource.component[1]);
-                            if (!strcmp(message->h.resource.component[2],"content-hosting-configuration")) {
-                                if(msaf_provisioning_session) {
-                                    cJSON *chc;
-                                    chc = msaf_get_content_hosting_configuration_by_provisioning_session_id(message->h.resource.component[1]);
-                                    if (chc != NULL) {
-                                        ogs_sbi_response_t *response;
-                                        char *text;
-                                        text = cJSON_Print(chc);
+                            if (!msaf_provisioning_session) {
+                                char *err = NULL;
+                                err = ogs_msprintf("Provisioning session [%s] is not available.", message->h.resource.component[1]);
+                                ogs_error("%s", err);
+                                ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Provisioning session does not exists.", err, NULL, api, app_meta));
+                                ogs_free(err);
+                            } else if (!api) {
+                                char *err = NULL;
+                                err = ogs_msprintf("Unknown sub-resource [%s] for provisioning session [%s].", message->h.resource.component[2], message->h.resource.component[1]);
+                                ogs_error("%s", err);
+                                ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Unknown provisioning session sub-resource.", err, NULL, m1_provisioningsession_api, app_meta));
+                                ogs_free(err);
+                            } else if (api == m1_contenthostingprovisioning_api) {
+                                cJSON *chc;
+                                chc = msaf_get_content_hosting_configuration_by_provisioning_session_id(message->h.resource.component[1]);
+                                if (chc != NULL) {
+                                    ogs_sbi_response_t *response;
+                                    char *text;
+                                    text = cJSON_Print(chc);
 
-                                        response = nf_server_new_response(request->h.uri, "application/json",  msaf_provisioning_session->contentHostingConfigurationReceived, msaf_provisioning_session->contentHostingConfigurationHash, msaf_self()->config.server_response_cache_control->m1_content_hosting_configurations_response_max_age, NULL, m1_contenthostingprovisioning_api, app_meta);
-                                        ogs_assert(response);
-                                        nf_server_populate_response(response, strlen(text), text, 200);
-                                        ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+                                    response = nf_server_new_response(request->h.uri, "application/json",  msaf_provisioning_session->httpMetadata.contentHostingConfiguration.received, msaf_provisioning_session->httpMetadata.contentHostingConfiguration.hash, msaf_self()->config.server_response_cache_control->m1_content_hosting_configurations_response_max_age, NULL, m1_contenthostingprovisioning_api, app_meta);
+                                    ogs_assert(response);
+                                    nf_server_populate_response(response, strlen(text), text, 200);
+                                    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
 
-                                        cJSON_Delete(chc);
-                                    } else {
-                                        char *err = NULL;
-                                        err = ogs_msprintf("Provisioning Session [%s]: Unable to retrieve the Content Hosting Configuration", message->h.resource.component[1]);
-                                        ogs_error("%s", err);
-                                        ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Unable to retrieve the Content Hosting Configuration.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
-                                        ogs_free(err);
-                                    }
-
+                                    cJSON_Delete(chc);
                                 } else {
                                     char *err = NULL;
-                                    err = ogs_msprintf("Provisioning Session [%s] does not exist.", message->h.resource.component[1]);
+                                    err = ogs_msprintf("Provisioning Session [%s]: Unable to retrieve the Content Hosting Configuration", message->h.resource.component[1]);
                                     ogs_error("%s", err);
-
-                                    ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Provisioning session does not exist.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
+                                    ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Unable to retrieve the Content Hosting Configuration.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
                                     ogs_free(err);
                                 }
 
-                            } else if (!strcmp(message->h.resource.component[2],"protocols")) {
-                                if(msaf_provisioning_session) {
-                                    ogs_sbi_response_t *response;
-                                    ogs_info("CONTENT_PROTOCOLS_DISCOVERY_JSON: %s", CONTENT_PROTOCOLS_DISCOVERY_JSON);
-                                    response = nf_server_new_response(NULL, "application/json",  CONTENT_PROTOCOLS_DISCOVERY_JSON_TIME, CONTENT_PROTOCOLS_DISCOVERY_JSON_HASH, msaf_self()->config.server_response_cache_control->m1_content_protocols_response_max_age, NULL, m1_contentprotocolsdiscovery_api, app_meta);
-                                    ogs_assert(response);
-                                    nf_server_populate_response(response, strlen(CONTENT_PROTOCOLS_DISCOVERY_JSON), msaf_strdup(CONTENT_PROTOCOLS_DISCOVERY_JSON), 200);
-                                    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
-                                } else {
+                            } else if (api == m1_contentprotocolsdiscovery_api) {
+                                ogs_sbi_response_t *response;
+                                ogs_info("CONTENT_PROTOCOLS_DISCOVERY_JSON: %s", CONTENT_PROTOCOLS_DISCOVERY_JSON);
+                                response = nf_server_new_response(NULL, "application/json",  CONTENT_PROTOCOLS_DISCOVERY_JSON_TIME, CONTENT_PROTOCOLS_DISCOVERY_JSON_HASH, msaf_self()->config.server_response_cache_control->m1_content_protocols_response_max_age, NULL, m1_contentprotocolsdiscovery_api, app_meta);
+                                ogs_assert(response);
+                                nf_server_populate_response(response, strlen(CONTENT_PROTOCOLS_DISCOVERY_JSON), msaf_strdup(CONTENT_PROTOCOLS_DISCOVERY_JSON), 200);
+                                ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+                            } else if (api == m1_consumptionreportingprovisioning_api) {
+                                ogs_sbi_response_t *response;
+                                char *body;
+
+                                ogs_debug("GET ConsumptionReportingConfiguration");
+
+                                body = msaf_consumption_report_configuration_body(msaf_provisioning_session);
+                                if (!body) {
                                     char *err = NULL;
-                                    err = ogs_msprintf("Provisioning Session [%s] does not exist.", message->h.resource.component[1]);
+                                    err = ogs_msprintf("Provisioning Session [%s]: Unable to retrieve the Consumption Reporting Configuration", message->h.resource.component[1]);
                                     ogs_error("%s", err);
-                                    ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Provisioning session does not exist.", err, NULL, m1_contentprotocolsdiscovery_api, app_meta));
+                                    ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Unable to retrieve the Consumption Reporting Configuration.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
                                     ogs_free(err);
+                                } else {
+                                    response = nf_server_new_response(NULL, NULL,
+                                            msaf_consumption_report_configuration_last_modified(msaf_provisioning_session),
+                                            msaf_consumption_report_configuration_etag(msaf_provisioning_session),
+                                            msaf_self()->config.server_response_cache_control->m1_consumption_reporting_response_max_age,
+                                            NULL, api, app_meta);
+                                    ogs_assert(response);
+                                    nf_server_populate_response(response, strlen(body), body, 200);
+                                    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
                                 }
                             }
                         } else if (message->h.resource.component[1] && !message->h.resource.component[2]) {
@@ -703,7 +789,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                 char *text;
                                 text = cJSON_Print(provisioning_session);
 
-                                response = nf_server_new_response(NULL, "application/json",  msaf_provisioning_session->provisioningSessionReceived, msaf_provisioning_session->provisioningSessionHash, msaf_self()->config.server_response_cache_control->m1_provisioning_session_response_max_age, NULL, m1_provisioningsession_api, app_meta);
+                                response = nf_server_new_response(NULL, "application/json",  msaf_provisioning_session->httpMetadata.provisioningSession.received, msaf_provisioning_session->httpMetadata.provisioningSession.hash, msaf_self()->config.server_response_cache_control->m1_provisioning_session_response_max_age, NULL, m1_provisioningsession_api, app_meta);
 
                                 nf_server_populate_response(response, strlen(text), text, 200);
                                 ogs_assert(response);
@@ -713,7 +799,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                 err = ogs_msprintf("Provisioning Session [%s] is not available.", message->h.resource.component[1]);
                                 ogs_error("%s", err);
 
-                                ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Provisioning session does not exists.", err, NULL, m1_provisioningsession_api, app_meta));
+                                ogs_assert(true == nf_server_send_error(stream, 404, 1, message, "Provisioning session does not exists.", err, NULL, m1_provisioningsession_api, app_meta));
                                 ogs_free(err);
                             }
                             if (provisioning_session) cJSON_Delete(provisioning_session);
@@ -722,13 +808,41 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
 
                     CASE(OGS_SBI_HTTP_METHOD_PUT)
                         if (message->h.resource.component[1] && message->h.resource.component[2]) {
-
-                            ogs_info("PUT: %s", message->h.resource.component[1]);
                             msaf_provisioning_session_t *msaf_provisioning_session;
+                            const nf_server_interface_metadata_t *api = NULL;
+
+                            ogs_debug("PUT: %s/%s", message->h.resource.component[1], message->h.resource.component[2]);
+
+                            SWITCH(message->h.resource.component[2])
+                            CASE("consumption-reporting-configuration")
+                                api = m1_consumptionreportingprovisioning_api;
+                                break;
+                            CASE("content-hosting-configuration")
+                                api = m1_contenthostingprovisioning_api;
+                                break;
+                            CASE("certificates")
+                                api = m1_servercertificatesprovisioning_api;
+                                break;
+                            DEFAULT
+                            END
+
                             msaf_provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(message->h.resource.component[1]);
-                            if(msaf_provisioning_session) {
-                                ogs_info("PUT: with msaf_provisioning_session: %s", message->h.resource.component[1]);
-                                if (!strcmp(message->h.resource.component[2],"content-hosting-configuration") && !message->h.resource.component[3]) {
+                            if (!msaf_provisioning_session) {
+                                char *err = NULL;
+                                err = ogs_msprintf("Provisioning Session [%s] is not available.", message->h.resource.component[1]);
+                                ogs_error("%s", err);
+
+                                ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Provisioning session does not exists.", err, NULL, api, app_meta));
+                                ogs_free(err);
+                            } else if (!api) {
+                                char *err = NULL;
+                                err = ogs_msprintf("Unknown sub-resource [%s] for provisioning Session [%s].", message->h.resource.component[2], message->h.resource.component[1]);
+                                ogs_error("%s", err);
+
+                                ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Unknown provisioning session sub-resource.", err, NULL, m1_provisioningsession_api, app_meta));
+                                ogs_free(err);
+                            } else if (api == m1_contenthostingprovisioning_api) {
+                                if (!message->h.resource.component[3]) {
 
                                     // process the PUT body
                                     int rv;
@@ -780,8 +894,21 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                         ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Failed to update the contentHostingConfiguration.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
                                         ogs_free(err);
                                     }
+                                } else {
+                                    char *err = NULL;
+                                    err = ogs_msprintf("Provisioning Session [%s]: "
+                                                       "Unknown Content Hosting Configuration sub-resource [%s].",
+                                                       message->h.resource.component[1],
+                                                       message->h.resource.component[3]);
+                                    ogs_error("%s", err);
+                                    ogs_assert(true == nf_server_send_error(stream, 404, 2, message,
+                                                                            "Unknown Content Hosting Configuration sub-resource.",
+                                                                            err, NULL, m1_contenthostingprovisioning_api, app_meta)
+                                            );
+                                    ogs_free(err);
                                 }
-                                else if (!strcmp(message->h.resource.component[2],"certificates") && message->h.resource.component[3] && !message->h.resource.component[4]) {
+                            } else if (api == m1_servercertificatesprovisioning_api) {
+                                if (message->h.resource.component[3] && !message->h.resource.component[4]) {
                                     char *cert_id;
                                     char *cert;
                                     int rv;
@@ -869,14 +996,45 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                     ogs_assert(true == nf_server_send_error(stream, 404, 1, message, "Resource not found.", err, NULL, m1_provisioningsession_api, app_meta));
                                     ogs_free(err);
                                 }
-                            } else {
-                                char *err = NULL;
-                                err = ogs_msprintf("Provisioning Session [%s] does not exist.", message->h.resource.component[1]);
-                                ogs_error("%s", err);
-                                ogs_assert(true == nf_server_send_error(stream, 404, 3, message, "Provisioning session does not exist.", err, NULL, m1_servercertificatesprovisioning_api, app_meta));
-                                ogs_free(err);
-                            }
+                            } else if (api == m1_consumptionreportingprovisioning_api) {
+                                cJSON *json;
 
+                                ogs_debug("PUT ConsumptionReportingConfiguration");
+
+                                json = cJSON_Parse(request->http.content);
+                                if (!json) {
+                                    char *err = NULL;
+                                    err = ogs_msprintf("Bad request body while updating ConsumptionReportingConfiguration for Provisioining Session [%s].", message->h.resource.component[1]);
+                                    ogs_error("%s", err);
+                                    ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Bad request.", err, NULL, api, app_meta));
+                                    ogs_free(err);
+                                } else {
+                                    OpenAPI_consumption_reporting_configuration_t *config;
+                                    config = OpenAPI_consumption_reporting_configuration_parseFromJSON(json);
+                                    if (!config) {
+                                        char *err = NULL;
+                                        err = ogs_msprintf("Bad request body while updating ConsumptionReportingConfiguration for Provisioining Session [%s].", message->h.resource.component[1]);
+                                        ogs_error("%s", err);
+                                        ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Bad request.", err, NULL, api, app_meta));
+                                        ogs_free(err);
+                                    } else {
+                                        if (!msaf_consumption_report_configuration_update(msaf_provisioning_session, config)) {
+                                            char *err = NULL;
+                                            err = ogs_msprintf("No ConsumptionReportingConfiguration for Provisioining Session [%s].", message->h.resource.component[1]);
+                                            ogs_error("%s", err);
+                                            ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Not found.", err, NULL, api, app_meta));
+                                            ogs_free(err);
+                                        } else {
+                                            ogs_sbi_response_t *response;
+                                            response = nf_server_new_response(NULL, NULL, 0, NULL, 0, NULL, api, app_meta);
+                                            ogs_assert(response);
+                                            nf_server_populate_response(response, 0, NULL, 204);
+                                            ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+                                        }
+                                    }
+                                    cJSON_Delete(json);
+                                }
+                            }
 
                         } else {
                             char *err = NULL;
@@ -889,89 +1047,156 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
 
                     CASE(OGS_SBI_HTTP_METHOD_DELETE)
 
-                        if (message->h.resource.component[1] && message->h.resource.component[2] && !strcmp(message->h.resource.component[2],"certificates") && message->h.resource.component[3] && !message->h.resource.component[4]) {
-                            ogs_sbi_response_t *response;
-                            msaf_provisioning_session_t *provisioning_session = NULL;
+                        if (message->h.resource.component[1] && message->h.resource.component[2]) {
+                            msaf_provisioning_session_t *provisioning_session;
+                            const nf_server_interface_metadata_t *api = NULL;
+
+                            ogs_debug("DELETE: %s/%s", message->h.resource.component[1], message->h.resource.component[2]);
+
+                            SWITCH(message->h.resource.component[2])
+                            CASE("consumption-reporting-configuration")
+                                api = m1_consumptionreportingprovisioning_api;
+                                break;
+                            CASE("content-hosting-configuration")
+                                api = m1_contenthostingprovisioning_api;
+                                break;
+                            CASE("certificates")
+                                api = m1_servercertificatesprovisioning_api;
+                                break;
+                            DEFAULT
+                            END
+
                             provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(message->h.resource.component[1]);
-                            if (provisioning_session) {
-                                int rv;
-                                rv = server_cert_delete(message->h.resource.component[3]);
-                                if ((rv == 0) || (rv == 8)){
-                                    response = nf_server_new_response(NULL, NULL,  0, NULL, 0, NULL, m1_servercertificatesprovisioning_api, app_meta);
-                                    nf_server_populate_response(response, 0, NULL, 204);
-                                    ogs_assert(response);
-                                    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
-                                    msaf_provisioning_session_certificate_hash_remove(message->h.resource.component[1], message->h.resource.component[3]);
-
-                                } else if (rv == 4 ) {
-                                    char *err = NULL;
-                                    err = ogs_msprintf("Certificate [%s] does not exist.", message->h.resource.component[3]);
-                                    ogs_error("%s", err);
-
-                                    ogs_assert(true == nf_server_send_error(stream, 404, 3, message, "Certificate does not exist.", err, NULL, m1_servercertificatesprovisioning_api, app_meta));
-                                    ogs_free(err);
-                                } else {
-                                    char *err = NULL;
-                                    err = ogs_msprintf("Certificate management problem for certificate [%s].", message->h.resource.component[3]);
-                                    ogs_error("%s", err);
-
-                                    ogs_assert(true == nf_server_send_error(stream, 500, 3, message, "Certificate management problem.", err, NULL, m1_servercertificatesprovisioning_api, app_meta));
-                                    ogs_free(err);
-                                }
-
-                            } else {
+                            if (!provisioning_session) {
                                 char *err = NULL;
-                                err = ogs_msprintf("Provisioning Session [%s] does not exist.", message->h.resource.component[1]);
+                                err = ogs_msprintf("Provisioning Session [%s] is not available.", message->h.resource.component[1]);
                                 ogs_error("%s", err);
 
-                                ogs_assert(true == nf_server_send_error(stream, 404, 3, message, "Provisioning session does not exist.", err, NULL, m1_servercertificatesprovisioning_api, app_meta));
+                                ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Provisioning session does not exists.", err, NULL, api, app_meta));
                                 ogs_free(err);
-                            }
-                        } else if (message->h.resource.component[1] && message->h.resource.component[2] && !message->h.resource.component[3]) {
-                            msaf_provisioning_session_t *msaf_provisioning_session;
-                            ogs_sbi_response_t *response;
-                            if (!strcmp(message->h.resource.component[2],"content-hosting-configuration")) {
-                                msaf_provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(message->h.resource.component[1]);
-                                if(msaf_provisioning_session){
-                                    if(msaf_provisioning_session && msaf_provisioning_session->contentHostingConfiguration) {
+                            } else if (!api) {
+                                char *err = NULL;
+                                err = ogs_msprintf("Unknown sub-resource [%s] for provisioning Session [%s].", message->h.resource.component[2], message->h.resource.component[1]);
+                                ogs_error("%s", err);
+
+                                ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Unknown provisioning session sub-resource.", err, NULL, m1_provisioningsession_api, app_meta));
+                                ogs_free(err);
+                            } else if (api == m1_contenthostingprovisioning_api) {
+                                /* Delete ContentHostingConfiguration operations */
+                                if (!message->h.resource.component[3]) {
+                                    /* Delete the ContentHostingConfiguration */
+                                    ogs_sbi_response_t *response;
+                                    if(provisioning_session && provisioning_session->contentHostingConfiguration) {
                                         msaf_delete_content_hosting_configuration(message->h.resource.component[1]);
-                                        OpenAPI_content_hosting_configuration_free(msaf_provisioning_session->contentHostingConfiguration);
-                                        msaf_provisioning_session->contentHostingConfiguration = NULL;
+                                        OpenAPI_content_hosting_configuration_free(provisioning_session->contentHostingConfiguration);
+                                        provisioning_session->contentHostingConfiguration = NULL;
                                         response = nf_server_new_response(NULL, NULL,  0, NULL, 0, NULL, m1_contenthostingprovisioning_api, app_meta);
                                         ogs_assert(response);
                                         nf_server_populate_response(response, 0, NULL, 204);
                                         ogs_assert(true == ogs_sbi_server_send_response(stream, response));
-                                        break;
                                     } else {
                                         char *err = NULL;
                                         err = ogs_msprintf("Provisioning Session [%s] has no Content Hosting Configuration.", message->h.resource.component[1]);
                                         ogs_error("%s", err);
-                                        ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Content Hosting Configuration does not exist.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
+                                        ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Content Hosting Configuration does not exist.", err, NULL, api, app_meta));
                                         ogs_free(err);
                                     }
                                 } else {
+                                    /* Delete the ContentHostingConfiguration with extra field - undefined operation */
                                     char *err = NULL;
-                                    err = ogs_msprintf("Provisioning Session [%s] does not exists.", message->h.resource.component[1]);
+                                    err = ogs_msprintf("Provisioning Session [%s]: Unknown ContentHostingConfiguration operation.", message->h.resource.component[1]);
                                     ogs_error("%s", err);
-                                    ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Provisioning session does not exist.", err, NULL, m1_contenthostingprovisioning_api, app_meta));
+
+                                    ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Bad request", err, NULL, api, app_meta));
                                     ogs_free(err);
                                 }
-
+                            } else if (api == m1_servercertificatesprovisioning_api) {
+                                if (message->h.resource.component[3]) {
+                                    if (message->h.resource.component[4]) {
+                                        /* Delete certificate with extra field - undefined operation */
+                                        char *err = NULL;
+                                        err = ogs_msprintf("Provisioning session [%s]: Certificate [%s]: Unknown delete operation.",
+                                                           message->h.resource.component[1], message->h.resource.component[3]);
+                                        ogs_error("%s", err);
+                                        ogs_assert(true == nf_server_send_error(stream, 400, 3, message, "Bad request.", err, NULL, api, app_meta));
+                                        ogs_free(err);
+                                    } else {
+                                        /* Delete one certificate by id */
+                                        ogs_sbi_response_t *response;
+                                        int rv;
+                                        rv = server_cert_delete(message->h.resource.component[3]);
+                                        if ((rv == 0) || (rv == 8)){
+                                            response = nf_server_new_response(NULL, NULL,  0, NULL, 0, NULL, m1_servercertificatesprovisioning_api, app_meta);
+                                            nf_server_populate_response(response, 0, NULL, 204);
+                                            ogs_assert(response);
+                                            ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+                                            msaf_provisioning_session_certificate_hash_remove(message->h.resource.component[1], message->h.resource.component[3]);
+                                        } else if (rv == 4 ) {
+                                            char *err = NULL;
+                                            err = ogs_msprintf("Certificate [%s] does not exist.", message->h.resource.component[3]);
+                                            ogs_error("%s", err);
+                                            ogs_assert(true == nf_server_send_error(stream, 404, 3, message, "Certificate does not exist.", err, NULL, m1_servercertificatesprovisioning_api, app_meta));
+                                            ogs_free(err);
+                                        } else {
+                                            char *err = NULL;
+                                            err = ogs_msprintf("Certificate management problem for certificate [%s].", message->h.resource.component[3]);
+                                            ogs_error("%s", err);
+                                            ogs_assert(true == nf_server_send_error(stream, 500, 3, message, "Certificate management problem.", err, NULL, api, app_meta));
+                                            ogs_free(err);
+                                        }
+                                    }
+                                } else {
+                                    /* Delete certificate without certificate id - undefined operation */
+                                    char *err = NULL;
+                                    err = ogs_msprintf("Provisioning session [%s]: Unknown Certificate Management operation.", message->h.resource.component[1]);
+                                    ogs_error("%s", err);
+                                    ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Bad request", err, NULL, api, app_meta));
+                                    ogs_free(err);
+                                }
+                            } else if (api == m1_consumptionreportingprovisioning_api) {
+                                if (!message->h.resource.component[3]) {
+                                    /* Delete consumption reporting configuration */
+                                    if (msaf_consumption_report_configuration_deregister(provisioning_session)) {
+                                        /* Deleted consumption reporting configuration successfully */
+                                        ogs_sbi_response_t *response;
+                                        response = nf_server_new_response(NULL, NULL,  0, NULL, 0, NULL, api, app_meta);
+                                        nf_server_populate_response(response, 0, NULL, 204);
+                                        ogs_assert(response);
+                                        ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+                                    } else {
+                                        /* Failed to delete consumption reporting configuration - no configuration to delete */
+                                        char *err = NULL;
+                                        err = ogs_msprintf("Provisioning session [%s]: Content Reporting Configuration not found.", message->h.resource.component[1]);
+                                        ogs_error("%s", err);
+                                        ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Not Found", err, NULL, api, app_meta));
+                                        ogs_free(err);
+                                    }
+                                } else {
+                                    /* Delete ConsumptionReportingConfiguration sub-resource - undefined operation */
+                                    char *err = NULL;
+                                    err = ogs_msprintf("Provisioning session [%s]: Unknown Consumption Reporting Configuration operation.", message->h.resource.component[1]);
+                                    ogs_error("%s", err);
+                                    ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Bad request", err, NULL, api, app_meta));
+                                    ogs_free(err);
+                                }
                             }
-
                         } else if (message->h.resource.component[1] && !message->h.resource.component[2]) {
-                            ogs_sbi_response_t *response;
-                            msaf_provisioning_session_t *provisioning_session = NULL;
-                            provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(message->h.resource.component[1]);
-                            if(!provisioning_session || provisioning_session->marked_for_deletion){
-                                char *err = NULL;
-                                err = ogs_msprintf("Provisioning session [%s] either not found or already marked for deletion.", message->h.resource.component[1]);
+                            msaf_provisioning_session_t *provisioning_session;
 
+                            ogs_debug("DELETE: %s", message->h.resource.component[1]);
+
+                            provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(message->h.resource.component[1]);
+                            if (!provisioning_session || provisioning_session->marked_for_deletion) {
+                                char *err = NULL;
+                                err = ogs_msprintf("Provisioning Session [%s] is not available.", message->h.resource.component[1]);
                                 ogs_error("%s", err);
 
-                                ogs_assert(true == nf_server_send_error(stream, 500, 3, message, "Provisioning session either not found or already marked for deletion.", err, NULL, m1_provisioningsession_api, app_meta));
+                                ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Provisioning session does not exists.", err, NULL, m1_provisioningsession_api, app_meta));
                                 ogs_free(err);
                             } else {
+                                /* Delete provisioning session */
+                                ogs_sbi_response_t *response;
+
                                 provisioning_session->marked_for_deletion = 1;
                                 response = nf_server_new_response(NULL, NULL,  0, NULL, 0, NULL, m1_provisioningsession_api, app_meta);
                                 ogs_assert(response);
@@ -980,6 +1205,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                 msaf_delete_content_hosting_configuration(message->h.resource.component[1]);
                                 msaf_delete_certificates(message->h.resource.component[1]);
                                 msaf_context_provisioning_session_free(provisioning_session);
+                                msaf_consumption_report_configuration_deregister(provisioning_session);
                                 msaf_provisioning_session_hash_remove(message->h.resource.component[1]);
                             }
                         } else {
@@ -1031,9 +1257,25 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                                 ogs_assert(true == ogs_sbi_server_send_response(stream, response));
                                             }
 
-                                        }  else if (!strcmp(message->h.resource.component[2],"content-hosting-configuration")) {
+                                        } else if (!strcmp(message->h.resource.component[2],"content-hosting-configuration")) {
                                             methods = ogs_msprintf("%s, %s, %s, %s, %s",OGS_SBI_HTTP_METHOD_POST, OGS_SBI_HTTP_METHOD_GET, OGS_SBI_HTTP_METHOD_PUT, OGS_SBI_HTTP_METHOD_DELETE, OGS_SBI_HTTP_METHOD_OPTIONS);
                                             response = nf_server_new_response(request->h.uri, NULL,  0, NULL, 0, methods, m1_contenthostingprovisioning_api, app_meta);
+                                            nf_server_populate_response(response, 0, NULL, 204);
+                                            ogs_assert(response);
+                                            ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+
+                                        } else if (!strcmp(message->h.resource.component[2],"consumption-reporting-configuration")) {
+                                            methods = ogs_msprintf("%s, %s, %s, %s, %s", OGS_SBI_HTTP_METHOD_POST,
+                                                                   OGS_SBI_HTTP_METHOD_GET, OGS_SBI_HTTP_METHOD_PUT,
+                                                                   OGS_SBI_HTTP_METHOD_DELETE, OGS_SBI_HTTP_METHOD_OPTIONS);
+                                            response = nf_server_new_response(request->h.uri, NULL,  0, NULL, 0, methods,
+                                                                              m1_consumptionreportingprovisioning_api, app_meta);
+                                            nf_server_populate_response(response, 0, NULL, 204);
+                                            ogs_assert(response);
+                                            ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+                                        } else if (!strcmp(message->h.resource.component[2],"protocols")) {
+                                            methods = ogs_msprintf("%s, %s", OGS_SBI_HTTP_METHOD_GET, OGS_SBI_HTTP_METHOD_OPTIONS);
+                                            response = nf_server_new_response(request->h.uri, NULL,  0, NULL, 0, methods, m1_contentprotocolsdiscovery_api, app_meta);
                                             nf_server_populate_response(response, 0, NULL, 204);
                                             ogs_assert(response);
                                             ogs_assert(true == ogs_sbi_server_send_response(stream, response));

--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -1414,7 +1414,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                         ogs_error("%s", err);
                         ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, 0, message, "Invalid resource name", err, NULL, NULL, app_meta));
                         ogs_free(err);
-                END	
+                END
                 break;
             DEFAULT
                 ogs_error("Invalid API name [%s]", message->h.service.name);

--- a/src/5gmsaf/msaf-m5-sm.c
+++ b/src/5gmsaf/msaf-m5-sm.c
@@ -102,7 +102,7 @@ void msaf_m5_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                 ogs_sbi_response_t *response;
                                 char *text;
                                 text = cJSON_Print(service_access_information);
-                                response = nf_server_new_response(NULL, "application/json",  msaf_provisioning_session->serviceAccessInformationCreated, msaf_provisioning_session->serviceAccessInformationHash, msaf_self()->config.server_response_cache_control->m5_service_access_information_response_max_age, NULL, m5_serviceaccessinformation_api, app_meta);
+                                response = nf_server_new_response(NULL, "application/json",  msaf_provisioning_session->httpMetadata.serviceAccessInformation.received, msaf_provisioning_session->httpMetadata.serviceAccessInformation.hash, msaf_self()->config.server_response_cache_control->m5_service_access_information_response_max_age, NULL, m5_serviceaccessinformation_api, app_meta);
                                 nf_server_populate_response(response, strlen(text), text, 200);
                                 ogs_assert(response);
                                 ogs_assert(true == ogs_sbi_server_send_response(stream, response));

--- a/src/5gmsaf/msaf.yaml.in
+++ b/src/5gmsaf/msaf.yaml.in
@@ -192,6 +192,7 @@ msaf:
         m1ContentHostingConfigurations: 60
         m1ServerCertificates: 60
         m1ContentProtocols: 86400
+        m1ConsumptionReportingConfiguration: 60
         m5ServiceAccessInformation: 60
 #
 # nrf:

--- a/src/5gmsaf/provisioning-session.c
+++ b/src/5gmsaf/provisioning-session.c
@@ -116,7 +116,7 @@ msaf_provisioning_session_get_json(const char *provisioning_session_id)
 
         provisioning_session->provisioning_session_id = msaf_provisioning_session->provisioningSessionId;
         provisioning_session->provisioning_session_type = msaf_provisioning_session->provisioningSessionType;
-	provisioning_session->asp_id = msaf_provisioning_session->aspId;
+        provisioning_session->asp_id = msaf_provisioning_session->aspId;
         provisioning_session->external_application_id = msaf_provisioning_session->externalApplicationId;
 
         provisioning_session->server_certificate_ids = (OpenAPI_set_t*)OpenAPI_list_create();
@@ -127,7 +127,7 @@ msaf_provisioning_session_get_json(const char *provisioning_session_id)
 
         provisioning_session_json = OpenAPI_provisioning_session_convertToJSON(provisioning_session);
 
-	OpenAPI_list_free(provisioning_session->server_certificate_ids);
+        OpenAPI_list_free(provisioning_session->server_certificate_ids);
         ogs_free(provisioning_session);
     } else {
         ogs_error("Unable to retrieve Provisioning Session [%s]", provisioning_session_id);
@@ -315,8 +315,8 @@ msaf_retrieve_certificates_from_map(msaf_provisioning_session_t *provisioning_se
                         if (certificate->state) ogs_free(certificate->state);
                         ogs_free(certificate);
                     }
-		    ogs_free(certs);
-		    certs = NULL;
+                    ogs_free(certs);
+                    certs = NULL;
                     break;
                 }
             }
@@ -347,7 +347,7 @@ msaf_distribution_create(cJSON *content_hosting_config, msaf_provisioning_sessio
 
     OpenAPI_content_hosting_configuration_t *content_hosting_configuration
         = OpenAPI_content_hosting_configuration_parseFromJSON(content_hosting_config);
-	
+
     if (content_hosting_configuration->distribution_configurations) {
         media_entry_point_list = OpenAPI_list_create();
         OpenAPI_list_for_each(content_hosting_configuration->distribution_configurations, dist_config_node) {
@@ -538,15 +538,14 @@ char *enumerate_provisioning_sessions(void)
         for (hi = ogs_hash_first(msaf_self()->provisioningSessions_map); hi; hi = ogs_hash_next(hi)) {
             const char *key = NULL;
             const char *val = NULL;
-	        char *provisioning_session = NULL;
+            char *provisioning_session = NULL;
             key = ogs_hash_this_key(hi);
             ogs_assert(key);
             val = ogs_hash_this_val(hi);
             ogs_assert(val);
-		    provisioning_session = ogs_msprintf("\"%s\", ", key);
-	        strcat(provisioning_sessions, provisioning_session);
-	        ogs_free(provisioning_session);
-	
+            provisioning_session = ogs_msprintf("\"%s\", ", key);
+            strcat(provisioning_sessions, provisioning_session);
+            ogs_free(provisioning_session);
         }
         provisioning_sessions[strlen(provisioning_sessions) - 2] = ']';
         provisioning_sessions[strlen(provisioning_sessions) - 1] = '\0';
@@ -656,7 +655,7 @@ url_path_create(const char* macro, const char* session_id, const msaf_applicatio
     }
 
     if (url_path_prefix[i-1] != '/')
-	url_path_prefix[i++] = '/';
+        url_path_prefix[i++] = '/';
     url_path_prefix[i] = '\0';
 
     return url_path_prefix;

--- a/src/5gmsaf/provisioning-session.h
+++ b/src/5gmsaf/provisioning-session.h
@@ -12,6 +12,7 @@ https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 #define MSAF_PROVISIONING_SESSION_H
 
 #include <regex.h>
+#include "openapi/model/consumption_reporting_configuration.h"
 #include "openapi/model/content_hosting_configuration.h"
 #include "openapi/model/service_access_information_resource.h"
 #include "openapi/model/provisioning_session.h"
@@ -23,21 +24,27 @@ https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 extern "C" {
 #endif
 
+typedef struct msaf_http_metadata_s {
+    time_t received;
+    char *hash;
+} msaf_http_metadata_t;
+
 typedef struct msaf_provisioning_session_s {
     char *provisioningSessionId;
     OpenAPI_provisioning_session_type_e provisioningSessionType;
     char *aspId;
     char *externalApplicationId;
+    OpenAPI_consumption_reporting_configuration_t *consumptionReportingConfiguration;
     OpenAPI_content_hosting_configuration_t *contentHostingConfiguration;
     OpenAPI_service_access_information_resource_t *serviceAccessInformation;
-    time_t provisioningSessionReceived;
-    char *provisioningSessionHash;
-    time_t contentHostingConfigurationReceived;
-    char *contentHostingConfigurationHash;
-    time_t serviceAccessInformationCreated;
-    char *serviceAccessInformationHash;
-    ogs_hash_t *certificate_map;
-    ogs_list_t application_server_states; //Type: msaf_application_server_state_ref_node_t *
+    struct {
+	msaf_http_metadata_t provisioningSession;
+	msaf_http_metadata_t consumptionReportingConfiguration;
+	msaf_http_metadata_t contentHostingConfiguration;
+	msaf_http_metadata_t serviceAccessInformation;
+    } httpMetadata;
+    ogs_hash_t *certificate_map;          //Type: char* => n/a (just used as a set - external tool manages data)
+    ogs_list_t application_server_states; //Type: msaf_application_server_state_ref_node_t*
     int marked_for_deletion;
 } msaf_provisioning_session_t;
 
@@ -56,7 +63,6 @@ extern OpenAPI_content_hosting_configuration_t *msaf_content_hosting_configurati
 extern int msaf_content_hosting_configuration_certificate_check(msaf_provisioning_session_t *provisioning_session);
 extern int msaf_distribution_certificate_check(void);
 
-extern ogs_hash_t *msaf_certificate_map();
 extern const char *msaf_get_certificate_filename(const char *provisioning_session_id, const char *certificate_id);
 extern ogs_list_t *msaf_retrieve_certificates_from_map(msaf_provisioning_session_t *provisioning_session);
 

--- a/src/5gmsaf/provisioning-session.h
+++ b/src/5gmsaf/provisioning-session.h
@@ -38,10 +38,10 @@ typedef struct msaf_provisioning_session_s {
     OpenAPI_content_hosting_configuration_t *contentHostingConfiguration;
     OpenAPI_service_access_information_resource_t *serviceAccessInformation;
     struct {
-	msaf_http_metadata_t provisioningSession;
-	msaf_http_metadata_t consumptionReportingConfiguration;
-	msaf_http_metadata_t contentHostingConfiguration;
-	msaf_http_metadata_t serviceAccessInformation;
+        msaf_http_metadata_t provisioningSession;
+        msaf_http_metadata_t consumptionReportingConfiguration;
+        msaf_http_metadata_t contentHostingConfiguration;
+        msaf_http_metadata_t serviceAccessInformation;
     } httpMetadata;
     ogs_hash_t *certificate_map;          //Type: char* => n/a (just used as a set - external tool manages data)
     ogs_list_t application_server_states; //Type: msaf_application_server_state_ref_node_t*

--- a/src/5gmsaf/response-cache-control.c
+++ b/src/5gmsaf/response-cache-control.c
@@ -20,16 +20,23 @@ void msaf_server_response_cache_control_set(void)
     server_response_cache_control->m1_content_hosting_configurations_response_max_age = SERVER_RESPONSE_MAX_AGE;
     server_response_cache_control->m1_server_certificates_response_max_age = SERVER_RESPONSE_MAX_AGE;
     server_response_cache_control->m1_content_protocols_response_max_age = M1_CONTENT_PROTOCOLS_RESPONSE_MAX_AGE;
+    server_response_cache_control->m1_consumption_reporting_response_max_age = SERVER_RESPONSE_MAX_AGE;
     server_response_cache_control->m5_service_access_information_response_max_age = SERVER_RESPONSE_MAX_AGE;
     msaf_self()->config.server_response_cache_control = server_response_cache_control;
 }
 
-void msaf_server_response_cache_control_set_from_config(int m1_provisioning_session_response_max_age, int m1_content_hosting_configurations_response_max_age, int m1_server_certificates_response_max_age, int m1_content_protocols_response_max_age, int m5_service_access_information_response_max_age)
+void msaf_server_response_cache_control_set_from_config(int m1_provisioning_session_response_max_age,
+        int m1_content_hosting_configurations_response_max_age, int m1_server_certificates_response_max_age,
+        int m1_content_protocols_response_max_age, int m1_consumption_reporting_response_max_age,
+        int m5_service_access_information_response_max_age)
 {
     msaf_self()->config.server_response_cache_control->m1_provisioning_session_response_max_age = m1_provisioning_session_response_max_age;
     msaf_self()->config.server_response_cache_control->m1_content_hosting_configurations_response_max_age = m1_content_hosting_configurations_response_max_age;
     msaf_self()->config.server_response_cache_control->m1_server_certificates_response_max_age = m1_server_certificates_response_max_age;
     msaf_self()->config.server_response_cache_control->m1_content_protocols_response_max_age = m1_content_protocols_response_max_age;
+    msaf_self()->config.server_response_cache_control->m1_consumption_reporting_response_max_age = m1_consumption_reporting_response_max_age;
     msaf_self()->config.server_response_cache_control->m5_service_access_information_response_max_age = m5_service_access_information_response_max_age;
 }
 
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/5gmsaf/response-cache-control.h
+++ b/src/5gmsaf/response-cache-control.h
@@ -25,11 +25,12 @@ typedef struct msaf_server_response_cache_control_s {
     int m1_content_hosting_configurations_response_max_age;
     int m1_server_certificates_response_max_age;
     int m1_content_protocols_response_max_age;
+    int m1_consumption_reporting_response_max_age;
     int m5_service_access_information_response_max_age;
 }msaf_server_response_cache_control_t;
 
 extern void msaf_server_response_cache_control_set(void);
-extern void msaf_server_response_cache_control_set_from_config(int m1_provisioning_session_response_max_age, int m1_content_hosting_configurations_response_max_age, int m1_server_certificates_response_max_age, int m1_content_protocols_response_max_age, int m5_service_access_information_response_max_age);
+extern void msaf_server_response_cache_control_set_from_config(int m1_provisioning_session_response_max_age, int m1_content_hosting_configurations_response_max_age, int m1_server_certificates_response_max_age, int m1_content_protocols_response_max_age, int m1_consumption_reporting_response_max_age, int m5_service_access_information_response_max_age);
 
 
 #ifdef __cplusplus

--- a/src/5gmsaf/server.c
+++ b/src/5gmsaf/server.c
@@ -60,7 +60,7 @@ ogs_sbi_response_t *nf_server_new_response(char *location, char *content_type, t
     {
         char *response_cache_control;
         response_cache_control = ogs_msprintf("max-age=%d", cache_control);
-        ogs_sbi_header_set(response->http.headers, "Cache-Control", response_cache_control);    	
+        ogs_sbi_header_set(response->http.headers, "Cache-Control", response_cache_control);
         ogs_free(response_cache_control);
     }
 

--- a/src/5gmsaf/server.h
+++ b/src/5gmsaf/server.h
@@ -11,29 +11,31 @@ https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 #ifndef NF_SERVER_H
 #define NF_SERVER_H
 
- #include "context.h"
-
+#include "context.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct nf_server_interface_metadata_s {
-	const char *api_title;
+    const char *api_title;
     const char *api_version;
 } nf_server_interface_metadata_t;
 
 typedef struct nf_server_app_metadata_s {
-	const char *app_name;
-	const char *app_version;
-	const char *server_name;
+    const char *app_name;
+    const char *app_version;
+    const char *server_name;
 } nf_server_app_metadata_t;
 
 extern bool nf_server_send_error(ogs_sbi_stream_t *stream,
         int status, int number_of_components, ogs_sbi_message_t *message,
-        const char *title, const char *detail, cJSON * problem_detail, const nf_server_interface_metadata_t *interface, const nf_server_app_metadata_t *app);
+        const char *title, const char *detail, cJSON * problem_detail, const nf_server_interface_metadata_t *interface,
+        const nf_server_app_metadata_t *app);
 
-extern ogs_sbi_response_t *nf_server_new_response(char *location, char *content_type, time_t last_modified, char *etag, int cache_control, char *allow_methods, const nf_server_interface_metadata_t *interface, const nf_server_app_metadata_t *app);
+extern ogs_sbi_response_t *nf_server_new_response(char *location, char *content_type, time_t last_modified, char *etag,
+        int cache_control, char *allow_methods, const nf_server_interface_metadata_t *interface,
+        const nf_server_app_metadata_t *app);
 extern ogs_sbi_response_t *nf_server_populate_response(ogs_sbi_response_t *response, int content_length, char *content, int status);
 
 #ifdef __cplusplus

--- a/src/5gmsaf/service-access-information.c
+++ b/src/5gmsaf/service-access-information.c
@@ -34,7 +34,7 @@ cJSON *msaf_context_retrieve_service_access_information(char *provisioning_sessi
     msaf_provisioning_session_t *provisioning_session_context = NULL;
     provisioning_session_context = msaf_provisioning_session_find_by_provisioningSessionId(provisioning_session_id);
     if (provisioning_session_context == NULL){
-	    ogs_error("Couldn't find the Provisioning Session ID [%s]", provisioning_session_id);    
+        ogs_error("Couldn't find the Provisioning Session ID [%s]", provisioning_session_id);    
         return NULL;
     }
     if (provisioning_session_context->serviceAccessInformation == NULL){

--- a/src/5gmsaf/utilities.c
+++ b/src/5gmsaf/utilities.c
@@ -30,7 +30,7 @@ time_t str_to_time(const char *str_time)
     strptime(str_time, "%a, %d %b %Y %H:%M:%S %Z", &tm);
     time = mktime(&tm);      
     return time;
-}	
+}
 
 const char *get_time(time_t time_epoch)
 {
@@ -53,8 +53,8 @@ char *read_file(const char *filename)
     /* open in read binary mode */
     f = fopen(filename, "rb");
     if (f == NULL) {
-	ogs_error("Unable to open file with name [%s]: %s", filename, strerror(errno));
-	return NULL;
+        ogs_error("Unable to open file with name [%s]: %s", filename, strerror(errno));
+        return NULL;
     }
     /* get the length */
     fseek(f, 0, SEEK_END);
@@ -71,18 +71,18 @@ char *read_file(const char *filename)
 
 int str_match(const char *line, const char *word_to_find) {
  
-  char* p = strstr(line,word_to_find);
-  if ((p==line) || (p!=NULL && !isalnum((unsigned char)p[-1])))
-  {
-     p += strlen(word_to_find);
-     if (!isalnum((unsigned char)*p))
-     {      
-       return 1;
-     } else {
-	return 0;
+    char* p = strstr(line,word_to_find);
+    if ((p==line) || (p!=NULL && !isalnum((unsigned char)p[-1])))
+    {
+        p += strlen(word_to_find);
+        if (!isalnum((unsigned char)*p))
+        {      
+            return 1;
+        } else {
+            return 0;
+        }
     }
-  }
-  return 0;
+    return 0;
 }
 
 char *get_path(const char *file)

--- a/tools/python3/lib/rt_m1_client/types.py
+++ b/tools/python3/lib/rt_m1_client/types.py
@@ -337,6 +337,67 @@ Distributions:
         '''
         return '\n'.join([DistributionConfiguration.format(d, indent) for d in chc['distributionConfigurations']])
 
+# TS 26.512 ConsumptionReportingConfiguration
+
+class ConsumptionReportingConfiguration(TypedDict, total=False):
+    '''
+    ConsumptionReportingConfiguration structure from TS 26.512
+    '''
+    reportingInterval: int
+    samplePercentage: float
+    locationReporting: bool
+    accessReporting: bool
+
+    @staticmethod
+    def fromJSON(crc_json: str) -> "ConsumptionReportingConfiguration":
+        '''Create a ConsumptionReportingConfiguration from a JSON string
+
+        :param str json: The JSON string to parse into a ConsumptionReportingConfiguration structure.
+
+        :return: The `ConsumptionReportingConfiguration` generated from the JSON string.
+
+        :raise ValueError: If the JSON could not be parsed.
+        '''
+        # parse the JSON
+        crc = json.loads(crc_json)
+        # validate types
+        if 'reportingInterval' in crc:
+            if not isinstance(crc['reportingInterval'], int):
+                raise ValueError('ConsumptionReportingConfiguration.reportingInterval must be an integer')
+            if crc['reportingInterval'] <= 0:
+                raise ValueError('ConsumptionReportingConfiguration.reportingInterval must be an integer greater than 0')
+        if 'samplePercentage' in crc:
+            if isinstance(crc['samplePercentage'], int):
+                crc['samplePercentage'] = float(crc['samplePercentage'])
+            if not isinstance(crc['samplePercentage'], float):
+                raise ValueError('ConsumptionReportingConfiguration.samplePercentage must be an integer or floating point number')
+            if crc['samplePercentage'] < 0.0 or crc['samplePercentage'] > 100.0:
+                raise ValueError('ConsumptionReportingConfiguration.samplePercentage must be between 0.0 and 100.0 inclusive')
+        if 'locationReporting' in crc:
+            if not isinstance(crc['locationReporting'], bool):
+                raise ValueError('ConsumptionReportingConfiguration.locationReporting must be a boolean')
+        if 'accessReporting' in crc:
+            if not isinstance(crc['accessReporting'], bool):
+                raise ValueError('ConsumptionReportingConfiguration.accessReporting must be a boolean')
+        # Validate against ContentHostingConfiguration type
+        return ConsumptionReportingConfiguration(crc)
+
+    @classmethod
+    def format(cls, crc: "ConsumptionReportingConfiguration", indent: int = 0) -> str:
+        prefix: str = ' ' * indent
+        ret: str = ''
+        if 'reportingInterval' in crc:
+            ret += f"{prefix}Reporting interval: {crc['reportingInterval']}s\n"
+        if 'samplePercentage' in crc:
+            ret += f"{prefix}Sample percentage: {crc['samplePercentage']}\n"
+        if 'locationReporting' in crc and crc['locationReporting']:
+            ret += f"{prefix}With location reporting\n"
+        if 'accessReporting' in crc and crc['accessReporting']:
+            ret += f"{prefix}With access reporting\n"
+        if len(ret) == 0:
+            ret = f'{prefix}Active with no parameters set\n'
+        return ret
+
 # TS 29.571 ProblemDetail
 class InvalidParamMandatory(TypedDict):
     '''

--- a/tools/python3/m1_client_cli.py
+++ b/tools/python3/m1_client_cli.py
@@ -40,12 +40,17 @@ Syntax:
     m1-client hosting update [-h] <address:port> <provisioning-session-id> <CHC-JSON-file>
     m1-client hosting delete [-h] <address:port> <provisioning-session-id>
     m1-client hosting purge [-h] <address:port> <provisioning-session-id> [<path-regex>]
+    m1-client consumption create [-h] <address:port> <provisioning-session-id> [-i <interval>] [-p <percentage>] [-l] [-a]
+    m1-client consumption show [-h] <address:port> <provisioning-session-id>
+    m1-client consumption update [-h] <address:port> <provisioning-session-id> [-i <interval>] [-p <percentage>] [-l] [-a]
+    m1-client consumption delete [-h] <address:port> <provisioning-session-id>
 '''
 
 import aiofiles
 import argparse
 import asyncio
 import datetime
+import os.path
 import sys
 from typing import Optional, Union
 
@@ -56,8 +61,8 @@ installed_packages_dir = '@python_packages_dir@'
 if os.path.isdir(installed_packages_dir) and installed_packages_dir not in sys.path:
     sys.path.append(installed_packages_dir)
 
-from rt_m1_client.client import M1Client, ProvisioningSessionResponse, ContentProtocolsResponse, ServerCertificateSigningRequestResponse, ServerCertificateResponse, ContentHostingConfigurationResponse
-from rt_m1_client.types import PROVISIONING_SESSION_TYPE_DOWNLINK, PROVISIONING_SESSION_TYPE_UPLINK, ContentHostingConfiguration
+from rt_m1_client.client import M1Client, ProvisioningSessionResponse, ContentProtocolsResponse, ServerCertificateSigningRequestResponse, ServerCertificateResponse, ContentHostingConfigurationResponse, ConsumptionReportingConfigurationResponse
+from rt_m1_client.types import PROVISIONING_SESSION_TYPE_DOWNLINK, PROVISIONING_SESSION_TYPE_UPLINK, ContentHostingConfiguration, ConsumptionReportingConfiguration
 from rt_m1_client.exceptions import M1Error
 
 async def cmd_provisioning_create(args: argparse.Namespace) -> int:
@@ -403,6 +408,61 @@ async def cmd_hosting_purge(args: argparse.Namespace) -> int:
         print(f'There were {resp} entries purged from the cache')
     return 0
 
+async def __consumptionReportingConfigurationFromArgs(args: argparse.Namespace) -> ConsumptionReportingConfiguration:
+    crc: ConsumptionReportingConfiguration = {}
+    if args.interval is not None:
+        crc['reportingInterval'] = args.interval
+    if args.percentage is not None:
+        crc['samplePercentage'] = args.percentage
+    if args.locationReport:
+        crc['locationReporting'] = True
+    if args.accessReport:
+        crc['accessReporting'] = True
+    return crc
+
+async def cmd_consumption_create(args: argparse.Namespace) -> int:
+    client = await getClient(args)
+    provisioning_session_id: ResourceId = args.provisioning_session_id
+    crc: ConsumptionReportingConfiguration = await __consumptionReportingConfigurationFromArgs(args)
+    resp: Union[bool, ConsumptionReportingConfigurationResponse] = await client.activateConsumptionReportingConfiguration(provisioning_session_id, crc)
+    if isinstance(resp, bool) and resp or isinstance(resp, ConsumptionReportingConfigurationResponse):
+        print('ConsumptionReportingConfiguration created')
+    return 0
+
+async def cmd_consumption_show(args: argparse.Namespace) -> int:
+    client = await getClient(args)
+    provisioning_session_id: ResourceId = args.provisioning_session_id
+    try:
+        resp: ConsumptionReportingConfigurationResponse = await client.retrieveConsumptionReportingConfiguration(provisioning_session_id)
+        print(ConsumptionReportingConfiguration.format(resp['ConsumptionReportingConfiguration']))
+    except M1ClientError as err:
+        if err.args[1] == 404:
+            print('No ConsumptionReportingConfiguration for provisioning session')
+        else:
+            raise err
+    return 0
+
+async def cmd_consumption_update(args: argparse.Namespace) -> int:
+    client = await getClient(args)
+    provisioning_session_id: ResourceId = args.provisioning_session_id
+    crc: ConsumptionReportingConfiguration = await __consumptionReportingConfigurationFromArgs(args)
+    resp: bool = await client.updateConsumptionReportingConfiguration(provisioning_session_id, crc)
+    if resp:
+        print('ConsumptionReportingConfiguration updated')
+    else:
+        print('ConsumptionReportingConfiguration update failed')
+    return 0
+
+async def cmd_consumption_delete(args: argparse.Namespace) -> int:
+    client = await getClient(args)
+    provisioning_session_id: ResourceId = args.provisioning_session_id
+    resp: bool = await client.destroyConsumptionReportingConfiguration(provisioning_session_id)
+    if resp:
+        print('ConsumptionReportingConfiguration deleted')
+    else:
+        print('ConsumptionReportingConfiguration failed to delete')
+    return 0
+
 async def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog='m1-client', description='M1 Client API tool')
     subparsers = parser.add_subparsers(required=True)
@@ -509,6 +569,46 @@ async def parse_args() -> argparse.Namespace:
     parser_hosting_purge.set_defaults(command=cmd_hosting_purge)
     parser_hosting_purge.add_argument('path_regex', metavar='path-regex', nargs='?',
                                       help='Regular expression to match for entries to purge')
+
+    # m1-client consumption ...
+    parser_consumption = subparsers.add_parser('consumption', help='ConsumptionReportingProvisioing APIs')
+    consumption_subparsers = parser_consumption.add_subparsers(required=True)
+
+    # m1-client consumption create [-h] <address:port> <provisioning-session-id> [-i <interval>] [-p <percentage>] [-l] [-a]
+    parser_consumption_create = consumption_subparsers.add_parser('create', parents=[parent_addr_prov],
+                                                                  help='Activate Consumption Reporting for a provisioning session')
+    parser_consumption_create.set_defaults(command=cmd_consumption_create)
+    parser_consumption_create.add_argument('-i','--interval', type=int, nargs=1,
+                                      help='The reporting interval for consumption reporting in whole seconds')
+    parser_consumption_create.add_argument('-p','--percentage', type=float, nargs=1,
+                                      help='The sample percentage to request for consumption reporting')
+    parser_consumption_create.add_argument('-l', '--location-reporting', action='store_true', dest='location_reporting',
+                                      help='Indicates that location reporting should be requested')
+    parser_consumption_create.add_argument('-a', '--access-reporting', action='store_true', dest='access_reporting',
+                                      help='Indicates that access reporting should be requested')
+
+    # m1-client consumption show [-h] <address:port> <provisioning-session-id>
+    parser_consumption_show = consumption_subparsers.add_parser('show', parents=[parent_addr_prov],
+                                                    help='Retrieve a ConsumptionReportingConfiguration for a provisioning session')
+    parser_consumption_show.set_defaults(command=cmd_consumption_show)
+
+    # m1-client consumption update [-h] <address:port> <provisioning-session-id> [-i <interval>] [-p <percentage>] [-l] [-a]
+    parser_consumption_update = consumption_subparsers.add_parser('update', parents=[parent_addr_prov],
+                                                                  help='Update Consumption Reporting for a provisioning session')
+    parser_consumption_update.set_defaults(command=cmd_consumption_update)
+    parser_consumption_update.add_argument('-i','--interval', type=int, nargs=1,
+                                      help='The reporting interval for consumption reporting in whole seconds')
+    parser_consumption_update.add_argument('-p','--percentage', type=float, nargs=1,
+                                      help='The sample percentage to request for consumption reporting')
+    parser_consumption_update.add_argument('-l', '--location-reporting', action='store_true', dest='location_reporting',
+                                      help='Indicates that location reporting should be requested')
+    parser_consumption_update.add_argument('-a', '--access-reporting', action='store_true', dest='access_reporting',
+                                      help='Indicates that access reporting should be requested')
+
+    # m1-client consumption delete [-h] <address:port> <provisioning-session-id>
+    parser_consumption_delete = consumption_subparsers.add_parser('delete', parents=[parent_addr_prov],
+                                                                  help='Delete the Consumption Reporting for a provisioning session')
+    parser_consumption_delete.set_defaults(command=cmd_consumption_delete)
 
     return parser.parse_args()
 

--- a/tools/python3/m1_sync_config.py
+++ b/tools/python3/m1_sync_config.py
@@ -91,7 +91,13 @@ This file defines the streams to configure and is located at
                         "contentType": "application/vnd.apple.mpegurl"
                     }
                 }
-            ]
+            ],
+            "consumptionReporting": {
+                "reportingInterval": 30,
+                "samplePercentage": 66.666,
+                "locationReporting": true,
+                "accessReporting": true,
+            }
         },
         "vod-root-1": {
             "name": "VoD Service Name",
@@ -99,7 +105,11 @@ This file defines the streams to configure and is located at
             "distributionConfigurations": [
                 {"domainNameAlias": "5gms-as.example.com"},
                 {"domainNameAlias": "5gms-as.example.com", "certificateId": "placeholder1"}
-            ]
+            ],
+            "consumptionReporting": {
+                "reportingInterval": 20,
+                "samplePercentage": 80,
+            }
         }
     },
     "vodMedia": [
@@ -147,8 +157,10 @@ identfier as the map key. This identifier can be used in the *vodMedia* list to
 identfiy the stream used for VoD media lists (media entry points described in
 the M8 interface). If a stream contains *entryPoint* fields in the
 *distributionConfigurations* then these will be advertised via M5 only and will
-not appear in the M8 entry points. See 3GPP TS 26.512 for a discription of what
-may appear in a DistributionConfiguration.
+not appear in the M8 entry points. The *consumptionReporting* parameters, if
+present, will configure consumption reporting for the Provisioning Session. See
+3GPP TS 26.512 for a discription of what may appear in a
+DistributionConfiguration or the ConsumptionReportingConfiguration.
 
 The *vodMedia* list is for describing media and their entry points that use a
 common Provisioning Session. The Provisioning Session is identfied by the
@@ -165,7 +177,7 @@ import json
 import logging
 import os.path
 import sys
-from typing import List
+from typing import List, Optional
 
 installed_packages_dir = '@python_packages_dir@'
 if os.path.isdir(installed_packages_dir) and installed_packages_dir not in sys.path:
@@ -174,7 +186,7 @@ if os.path.isdir(installed_packages_dir) and installed_packages_dir not in sys.p
 from rt_m1_client.session import M1Session
 from rt_m1_client.exceptions import M1Error
 from rt_m1_client.data_store import JSONFileDataStore
-from rt_m1_client.types import ContentHostingConfiguration, DistributionConfiguration, IngestConfiguration, M1MediaEntryPoint, PathRewriteRule
+from rt_m1_client.types import ContentHostingConfiguration, DistributionConfiguration, IngestConfiguration, M1MediaEntryPoint, PathRewriteRule, ConsumptionReportingConfiguration
 
 g_streams_config = os.path.join(os.path.sep, 'etc', 'rt-5gms', 'streams.json')
 g_sync_config = os.path.join(os.path.sep, 'etc', 'rt-5gms', 'af-sync.conf')
@@ -268,6 +280,42 @@ async def distrib_configs_equal(a: List[DistributionConfiguration], b: List[Dist
             return False
     return True
 
+async def _flagsEqual(a: Optional[bool], b: Optional[bool]) -> bool:
+    if a is None and b is None:
+        return True
+    if a is None and b is not None and not b:
+        return True
+    if b is None and a is not None and not a:
+        return True
+    if a is not None and b is not None and a == b:
+        return True
+    return False
+
+async def consumption_reporting_equal(a: Optional[ConsumptionReportingConfiguration], b: Optional[ConsumptionReportingConfiguration]) -> bool:
+    if a is None and b is None:
+        return True
+    if a is None and b is not None:
+        return False
+    if b is None and a is not None:
+        return False
+    if not await _flagsEqual(a.get('locationReporting'), b.get('locationReporting')):
+        return False
+    if not await _flagsEqual(a.get('accessReporting'), b.get('accessReporting')):
+        return False
+    if 'reportingInterval' in a and 'reportingInterval' not in b:
+        return False
+    if 'reportingInterval' in b and 'reportingInterval' not in a:
+        return False
+    if 'reportingInterval' in a and a['reportingInterval'] != b['reportingInterval']:
+        return False
+    if 'samplePercentage' in a and 'samplePercentage' not in b:
+        return False
+    if 'samplePercentage' in b and 'samplePercentage' not in a:
+        return False
+    if 'samplePercentage' in a and a['samplePercentage'] != b['samplePercentage']:
+        return False
+    return True
+
 async def sync_configuration(m1: M1Session, streams: dict) -> dict:
     have = {}
     to_check = streams['streams']
@@ -303,6 +351,7 @@ async def sync_configuration(m1: M1Session, streams: dict) -> dict:
                 },
                 'distributionConfigurations': cfg['distributionConfigurations'],
                 }
+        crc = cfg.get('consumptionReporting')
         ps_id = await m1.createDownlinkPullProvisioningSession(streams.get('appId'), streams.get('aspId', None))
         if ps_id is None:
             log_error("Failed to create Provisioning Session for %r", cfg)
@@ -324,6 +373,27 @@ async def sync_configuration(m1: M1Session, streams: dict) -> dict:
             if chc is not None:
                 if not await m1.contentHostingConfigurationCreate(ps_id, chc):
                     log_error("Failed to create ContentHostingConfiguration for Provisioning Session %s, skipping %r", ps_id, cfg)
+            if crc is not None:
+                if not await m1.consumptionReportingConfigurationCreate(ps_id, crc):
+                    log_error("Failed to activate ConsumptionReportingConfiguration for Provisioning Session %s")
+    # Check for ConsumptionReportingConfiguration changes in already configured sessions
+    for cfg_id, cfg in have.items():
+        ps_id = stream_map[cfg_id]
+        old_crc: Optional[ConsumptionReportingConfiguration] = await m1.consumptionReportingConfigurationGet(ps_id)
+        new_crc: Optional[ConsumptionReportingConfiguration] = cfg.get('consumptionReporting')
+        if not await consumption_reporting_equal(old_crc, new_crc):
+            if old_crc is None:
+                # No pre-existing CRC, add the new one
+                if not await m1.consumptionReportingConfigurationCreate(ps_id, new_crc):
+                    log_error("Failed to activate ConsumptionReportingConfiguration for Provisioning Session %s", ps_id)
+            elif new_crc is None:
+                # There is a CRC, but shouldn't be one, remove it
+                if not await m1.consumptionReportingConfigurationDelete(ps_id):
+                    log_error("Failed to remove ConsumptionReportingConfiguration for Provisioning Session %s", ps_id)
+            else:
+                # The CRC has changed, update it
+                if not await m1.consumptionReportingConfigurationUpdate(ps_id, new_crc):
+                    log_error("Failed to update ConsumptionReportingConfiguration for Provisioning Session %s", ps_id)
     return stream_map
 
 async def get_app_config() -> configparser.ConfigParser:


### PR DESCRIPTION
This change adds the Consumption Reporting Provisioning API to the interface at M1 and updates the M1 command line tools with the new operations.

This change also includes a few bug fixes, code improvements and the missing OPTIONS for the content protocols discovery API on M1.

The consumption reporting configuration is implemented as a single optional instance held in the provisioning session.

The GET, PUT, POST, DELETE and OPTIONS operations have been implemented. The PATCH operation has not been implemented.

The python tools now accept new commands or configuration in order to configure a consumption reporting configuration.
- `m1-client`
  - `m1-client consumption create <address:port> <provisioning-session-id> [-i SECONDS] [-p PERCENT] [-l] [-a]` - Add a new consumption reporting configuration to the provisioning session.
  - `m1-client consumption show <address:port> <provisioning-session-id>` - Display the consumption reporting configuration for a provisioning session.
  - `m1-client consumption update <address:port> <provisioning-session-id> [-i SECONDS] [-p PERCENT] [-l] [-a]` - Change the existing consumption reporting configuration for one using the new parameters.
  - `m1-client consumption delete <address:port> <provisioning-session-id>` - Remove the consumption reporting configuration from a provisioning session.
- `m1-session`
  - `m1-session list -v` - will now display the consumption reporting configuration with the rest of the provisioning session information.
  - `m1-session set-consumption-reporting  -p PROVISIONING_SESSION [-i INTERVAL] [-s SAMPLE_PERCENTAGE] [-l] [-A]` - Create or update the consumption reporting configuration for a provisioning session.
  - `m1-session show-consumption-reporting -p PROVISIONING_SESSION` - Display the consumption reporting configuration for the provisioning session.
  - `m1-session del-consumption-reporting -p PROVISIONING_SESSION` - Remove the consumption reporting configuration from a provisioning session.
- `msaf-configuration`
  - The `/etc/rt-5gms/streams.json` configuration file can now take `ConsumptionReportingConfiguration` objects at the `streams[<name>].consumptionReporting` field. For example:
    ```json
    {
        "aspId": "MyASPId",
        "appId": "BBCRD5GTestbed",
        "streams": {
            "ed": {
                "name": "Elephant's Dream [AMS]",
                "ingestURL": "http://amssamples.streaming.mediaservices.windows.net/b6822ec8-5c2b-4ae0-a851-fd46a78294e9/ElephantsDream.ism/",
                "distributionConfigurations": [
                    {
                        "entryPoint": {
                            "relativePath": "manifest(format=mpd-time-csf)",
                            "contentType": "application/dash+xml",
                            "profiles": ["urn:mpeg:dash:profile:isoff-live:2011"]
                        }
                    },
                    {
                        "entryPoint": {
                            "relativePath": "manifest(format=m3u8-aapl-v3)",
                            "contentType": "application/vnd.apple.mpegurl"
                        }
                    }
                ],
                "consumptionReporting": {
                    "reportingInterval": 60,
                    "samplePercentage": 66.666,
                    "locationReporting": true,
                    "accessReporting": true
                }
            }
        }
    }
    ```