### PR TITLE
Feature: SAI - Consumption Reporting

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,10 +20,16 @@ project('rt-5gms-application-function', 'c',
 sh_cmd = find_program('sh')
 patch_open5gs_result = run_command([sh_cmd, '-c', '"$MESON_SOURCE_ROOT/subprojects/patch_open5gs.sh" open5gs'], check: true, capture: false)
 open5gs_project=subproject('open5gs',required:true)
+
+build_tests = open5gs_project.get_variable('build_tests')
+
 subdir('tools')
 subdir('src')
 
 systemd_path_cmd = find_program('systemd-path', required : false)
 if systemd_path_cmd.found()
   subdir('systemd')
+endif
+if build_tests
+    subdir('tests')
 endif

--- a/src/5gmsaf/consumption-report-configuration.c
+++ b/src/5gmsaf/consumption-report-configuration.c
@@ -34,6 +34,8 @@ bool msaf_consumption_report_configuration_register(msaf_provisioning_session_t 
 
     time(&session->httpMetadata.consumptionReportingConfiguration.received);
 
+    msaf_sai_cache_clear(session->sai_cache);
+
     return true;
 }
 
@@ -61,6 +63,8 @@ bool msaf_consumption_report_configuration_update(msaf_provisioning_session_t *s
 
     time(&session->httpMetadata.consumptionReportingConfiguration.received);
 
+    msaf_sai_cache_clear(session->sai_cache);
+
     return true;
 }
 
@@ -79,6 +83,8 @@ bool msaf_consumption_report_configuration_deregister(msaf_provisioning_session_
     }
     
     session->httpMetadata.consumptionReportingConfiguration.received = 0;
+
+    msaf_sai_cache_clear(session->sai_cache);
 
     return true;
 }

--- a/src/5gmsaf/context.c
+++ b/src/5gmsaf/context.c
@@ -674,34 +674,9 @@ free_ogs_hash_entry(void *rec, const void *key, int klen, const void *value)
 void
 msaf_context_provisioning_session_free(msaf_provisioning_session_t *provisioning_session)
 {
-    msaf_application_server_state_ref_node_t *next_as_state_ref, *as_state_ref;
-
     ogs_assert(provisioning_session);
-    if (provisioning_session->certificate_map) {
-        free_ogs_hash_context_t fohc = {
-            safe_ogs_free,
-            provisioning_session->certificate_map
-        };
-        ogs_hash_do(free_ogs_hash_entry, &fohc, provisioning_session->certificate_map);
-        ogs_hash_destroy(provisioning_session->certificate_map);
-    }
-    if (provisioning_session->provisioningSessionId) ogs_free(provisioning_session->provisioningSessionId);
-    if (provisioning_session->aspId) ogs_free(provisioning_session->aspId);
-    if (provisioning_session->externalApplicationId) ogs_free(provisioning_session->externalApplicationId);
-    if (provisioning_session->httpMetadata.provisioningSession.hash) ogs_free(provisioning_session->httpMetadata.provisioningSession.hash);
 
-    if (provisioning_session->contentHostingConfiguration) OpenAPI_content_hosting_configuration_free(provisioning_session->contentHostingConfiguration);
-    if (provisioning_session->httpMetadata.contentHostingConfiguration.hash) ogs_free(provisioning_session->httpMetadata.contentHostingConfiguration.hash);
-
-    if (provisioning_session->serviceAccessInformation) OpenAPI_service_access_information_resource_free(provisioning_session->serviceAccessInformation);
-    if (provisioning_session->httpMetadata.serviceAccessInformation.hash) ogs_free(provisioning_session->httpMetadata.serviceAccessInformation.hash);
-    
-    ogs_list_for_each_safe(&provisioning_session->application_server_states, next_as_state_ref, as_state_ref) {
-        ogs_list_remove(&provisioning_session->application_server_states, as_state_ref);
-        ogs_free(as_state_ref);
-    }
-    
-    ogs_free(provisioning_session);
+    msaf_provisioning_session_free(provisioning_session);
 }
 
 static void

--- a/src/5gmsaf/meson.build
+++ b/src/5gmsaf/meson.build
@@ -26,41 +26,50 @@ fiveg_api_release = get_option('fiveg_api_release')
 fs = import('fs')
 
 libmsaf_dist_sources = files('''
+    application-server-context.h
+    application-server-context.c
+    certmgr.c
+    certmgr.h
+    consumption-report-configuration.c
+    consumption-report-configuration.h
     context.c
     context.h
     event.c
     event.h
-    server.h
-    server.c
-    certmgr.c
-    certmgr.h
     hash.h
     hash.c
-    headers.c
     headers.h
+    headers.c
+    init.h
+    init.c
+    msaf-fsm.h
+    msaf-fsm.c
+    msaf-m1-sm.c
+    msaf-m5-sm.c
+    msaf-mgmt-sm.c
+    msaf-sm.h
+    msaf-sm.c
     response-cache-control.h
     response-cache-control.c
     provisioning-session.h
     provisioning-session.c
-    application-server-context.h
-    application-server-context.c   
-    sbi-path.c
+    sai-cache.h
+    sai-cache.c
     sbi-path.h
+    sbi-path.c
+    server.h
+    server.c
     service-access-information.h
     service-access-information.c
-    msaf-fsm.h
-    msaf-fsm.c
-    msaf-sm.h
-    msaf-sm.c
-    msaf-mgmt-sm.c
-    msaf-m1-sm.c
-    msaf-m5-sm.c
     utilities.h
     utilities.c
-    init.h
-    init.c
-    consumption-report-configuration.c
-    consumption-report-configuration.h
+'''.split())
+
+msaf_test_sources = files('''
+    hash.c
+    hash.h
+    sai-cache.c
+    sai-cache.h
 '''.split())
 
 api_tag = latest_apis?'REL-'+fiveg_api_release:'TSG'+fiveg_api_approval+'-Rel'+fiveg_api_release
@@ -70,6 +79,8 @@ message('Generating OpenAPI bindings for version '+api_tag+' of the 5G APIs...')
 openapi_dep_file = meson.current_source_dir() / '.openapi.deps'
 openapi_gen_result = run_command([gen_5gmsaf_openapi,'-c','"$MESON_SOURCE_ROOT/$MESON_SUBDIR/generator-5gmsaf" -M '+openapi_dep_file+' -b '+api_tag], check: true, capture: false)
 libmsaf_gen_sources = files(fs.read(openapi_dep_file).split())
+
+msaf_test_sources += libmsaf_gen_sources
 
 json_file = files(['ContentProtocolsDiscovery_body.json'])
 file_content = ''

--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -15,6 +15,7 @@
 #include "context.h"
 #include "certmgr.h"
 #include "server.h"
+#include "sai-cache.h"
 #include "response-cache-control.h"
 #include "msaf-version.h"
 #include "msaf-sm.h"
@@ -297,14 +298,9 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                         OpenAPI_content_hosting_configuration_free(
                                                 msaf_provisioning_session->contentHostingConfiguration);
                                         msaf_provisioning_session->contentHostingConfiguration = NULL;
+                                        msaf_sai_cache_clear(msaf_provisioning_session->sai_cache);
                                     }
 
-                                    if (msaf_provisioning_session->serviceAccessInformation) {
-                                        OpenAPI_service_access_information_resource_free(
-                                                msaf_provisioning_session->serviceAccessInformation);
-                                        msaf_provisioning_session->serviceAccessInformation = NULL;
-                                    }
-    
                                     rv = msaf_distribution_create(content_hosting_config, msaf_provisioning_session);
                                     content_hosting_config = NULL;
     
@@ -866,11 +862,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                     if(msaf_provisioning_session->contentHostingConfiguration) {
                                         OpenAPI_content_hosting_configuration_free(msaf_provisioning_session->contentHostingConfiguration);
                                         msaf_provisioning_session->contentHostingConfiguration = NULL;
-                                    }
-
-                                    if (msaf_provisioning_session->serviceAccessInformation) {
-                                        OpenAPI_service_access_information_resource_free(msaf_provisioning_session->serviceAccessInformation);
-                                        msaf_provisioning_session->serviceAccessInformation = NULL;
+                                        msaf_sai_cache_clear(msaf_provisioning_session->sai_cache);
                                     }
 
                                     rv = msaf_distribution_create(content_hosting_config, msaf_provisioning_session);

--- a/src/5gmsaf/provisioning-session.c
+++ b/src/5gmsaf/provisioning-session.c
@@ -11,9 +11,11 @@ https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 #include <time.h>
 #include "application-server-context.h"
 #include "certmgr.h"
+#include "consumption-report-configuration.h"
 #include "context.h"
 #include "utilities.h"
 #include "hash.h"
+#include "sai-cache.h"
 
 #include "provisioning-session.h"
 
@@ -27,15 +29,22 @@ typedef struct free_ogs_hash_provisioning_session_certificate_s {
     ogs_hash_t *hash;
 } free_ogs_hash_provisioning_session_certificate_t;
 
+typedef void (*free_ogs_hash_context_free_value_fn)(void *value);
+typedef struct free_ogs_hash_context_s {
+    free_ogs_hash_context_free_value_fn value_free_fn;
+    ogs_hash_t *hash;
+} free_ogs_hash_context_t;
+
 static regex_t *relative_path_re = NULL;
 
+static void safe_ogs_free(void *ptr);
 static int ogs_hash_do_cert_check(void *rec, const void *key, int klen, const void *value);
+static int free_ogs_hash_entry(void *free_ogs_hash_context, const void *key, int klen, const void *value);
 static int free_ogs_hash_provisioning_session(void *rec, const void *key, int klen, const void *value);
 static int free_ogs_hash_provisioning_session_certificate(void *rec, const void *key, int klen, const void *value);
 static char* url_path_create(const char* macro, const char* session_id, const msaf_application_server_node_t *msaf_as);
 static void tidy_relative_path_re(void);
 static char *calculate_provisioning_session_hash(OpenAPI_provisioning_session_t *provisioning_session);
-static char *calculate_service_access_information_hash(OpenAPI_service_access_information_resource_t *service_access_information);
 static ogs_hash_t *msaf_certificate_map();
 
 /***** Public functions *****/
@@ -96,6 +105,42 @@ msaf_provisioning_session_create(const char *provisioning_session_type, const ch
     OpenAPI_provisioning_session_free(provisioning_session);
 
     return msaf_provisioning_session;
+}
+
+void msaf_provisioning_session_free(msaf_provisioning_session_t *provisioning_session)
+{
+    msaf_application_server_state_ref_node_t *next_as_state_ref, *as_state_ref;
+
+    if (!provisioning_session) return;
+
+    ogs_debug("msaf_provisioning_session_free(%p) [%s]", provisioning_session, provisioning_session->provisioningSessionId);
+
+    if (provisioning_session->certificate_map) {
+        free_ogs_hash_context_t fohc = {
+            safe_ogs_free,
+            provisioning_session->certificate_map
+        };
+        ogs_hash_do(free_ogs_hash_entry, &fohc, provisioning_session->certificate_map);
+        ogs_hash_destroy(provisioning_session->certificate_map);
+    }
+    safe_ogs_free(provisioning_session->provisioningSessionId);
+    safe_ogs_free(provisioning_session->aspId);
+    safe_ogs_free(provisioning_session->externalApplicationId);
+    safe_ogs_free(provisioning_session->httpMetadata.provisioningSession.hash);
+    if (provisioning_session->contentHostingConfiguration) {
+        OpenAPI_content_hosting_configuration_free(provisioning_session->contentHostingConfiguration);
+    }
+    safe_ogs_free(provisioning_session->httpMetadata.contentHostingConfiguration.hash);
+    msaf_consumption_report_configuration_deregister(provisioning_session);
+
+    msaf_sai_cache_free(provisioning_session->sai_cache);
+
+    ogs_list_for_each_safe(&provisioning_session->application_server_states, next_as_state_ref, as_state_ref) {
+        ogs_list_remove(&provisioning_session->application_server_states, as_state_ref);
+        ogs_free(as_state_ref);
+    }
+
+    ogs_free(provisioning_session);
 }
 
 cJSON *
@@ -329,17 +374,12 @@ int
 msaf_distribution_create(cJSON *content_hosting_config, msaf_provisioning_session_t *provisioning_session)
 {
     OpenAPI_lnode_t *dist_config_node = NULL;
-    OpenAPI_lnode_t *media_entry_point_profile_node = NULL;
     OpenAPI_distribution_configuration_t *dist_config = NULL;
     char *url_path;
     char *domain_name;
     static const char macro[] = "{provisioningSessionId}";
     msaf_application_server_node_t *msaf_as = NULL;
     char *content_hosting_config_to_hash = NULL;
-    OpenAPI_list_t *media_entry_point_list = NULL;
-    OpenAPI_list_t *media_entry_point_profiles_list = NULL;
-    OpenAPI_m5_media_entry_point_t *entry_point;
-    char *locator_absolute_path;
 
     msaf_as = ogs_list_first(&msaf_self()->config.applicationServers_list);
 
@@ -349,34 +389,23 @@ msaf_distribution_create(cJSON *content_hosting_config, msaf_provisioning_sessio
         = OpenAPI_content_hosting_configuration_parseFromJSON(content_hosting_config);
 
     if (content_hosting_configuration->distribution_configurations) {
-        media_entry_point_list = OpenAPI_list_create();
         OpenAPI_list_for_each(content_hosting_configuration->distribution_configurations, dist_config_node) {
             char *protocol = "http";
 
             dist_config = (OpenAPI_distribution_configuration_t*)dist_config_node->data;
 
             if(dist_config->entry_point && !uri_relative_check(dist_config->entry_point->relative_path)) {
-                OpenAPI_lnode_t *node;
                 ogs_error("distributionConfiguration.entryPoint.relativePath malformed for Provisioning Session [%s]", provisioning_session->provisioningSessionId);
                 cJSON_Delete(content_hosting_config);
                 ogs_free(url_path);
-                OpenAPI_list_for_each(media_entry_point_list, node) {
-                    OpenAPI_m5_media_entry_point_free(node->data);
-                }
-                OpenAPI_list_free(media_entry_point_list);
                 if (content_hosting_configuration) OpenAPI_content_hosting_configuration_free(content_hosting_configuration);
                 return 0;
             }
 
             if (dist_config->entry_point && dist_config->entry_point->profiles && dist_config->entry_point->profiles->first == NULL) {
-                OpenAPI_lnode_t *node;
                 ogs_error("distributionConfiguration.entryPoint.profiles present but empty for Provisioning Session [%s]", provisioning_session->provisioningSessionId);
                 cJSON_Delete(content_hosting_config);
                 ogs_free(url_path);
-                OpenAPI_list_for_each(media_entry_point_list, node) {
-                    OpenAPI_m5_media_entry_point_free(node->data);
-                }
-                OpenAPI_list_free(media_entry_point_list);
                 if (content_hosting_configuration) OpenAPI_content_hosting_configuration_free(content_hosting_configuration);
                 return 0;
             }
@@ -398,34 +427,14 @@ msaf_distribution_create(cJSON *content_hosting_config, msaf_provisioning_sessio
             if(dist_config->base_url) ogs_free(dist_config->base_url);
 
             dist_config->base_url = ogs_msprintf("%s://%s%s", protocol, domain_name, url_path);
-
-            if (dist_config->entry_point) {
-                locator_absolute_path = ogs_msprintf("%s%s", dist_config->base_url, dist_config->entry_point->relative_path);
-                if(dist_config->entry_point->profiles){
-                    media_entry_point_profiles_list = OpenAPI_list_create();
-                    OpenAPI_list_for_each(dist_config->entry_point->profiles, media_entry_point_profile_node) {
-                        OpenAPI_list_add(media_entry_point_profiles_list, msaf_strdup((char *)media_entry_point_profile_node->data));
-                    }
-                } else {
-                    media_entry_point_profiles_list = NULL;
-                }
-
-                entry_point = OpenAPI_m5_media_entry_point_create(locator_absolute_path, msaf_strdup(dist_config->entry_point->content_type), media_entry_point_profiles_list);
-                OpenAPI_list_add(media_entry_point_list, entry_point);
-            }
         } 
     } else {
         ogs_error("The Content Hosting Configuration has no distributionConfigurations for Provisioning Session [%s]", provisioning_session->provisioningSessionId);
     }
-   
-    if (provisioning_session->serviceAccessInformation)
-        OpenAPI_service_access_information_resource_free(provisioning_session->serviceAccessInformation);
-    provisioning_session->serviceAccessInformation = msaf_context_service_access_information_create(provisioning_session->provisioningSessionId, media_entry_point_list);
-    provisioning_session->httpMetadata.serviceAccessInformation.received = time(NULL);
-    if (provisioning_session->httpMetadata.serviceAccessInformation.hash)
-        ogs_free(provisioning_session->httpMetadata.serviceAccessInformation.hash);
-    provisioning_session->httpMetadata.serviceAccessInformation.hash = calculate_service_access_information_hash(provisioning_session->serviceAccessInformation);
-    
+
+    /* reset Service Access Information cache */
+    msaf_sai_cache_clear(provisioning_session->sai_cache);
+
     if (provisioning_session->contentHostingConfiguration)
         OpenAPI_content_hosting_configuration_free(provisioning_session->contentHostingConfiguration);
     provisioning_session->contentHostingConfiguration = content_hosting_configuration;
@@ -558,6 +567,12 @@ char *enumerate_provisioning_sessions(void)
  * Private functions
  **********************************************************/
 
+static void safe_ogs_free(void *ptr)
+{
+    if (!ptr) return;
+    ogs_free(ptr);
+}
+
 static ogs_hash_t *
 msaf_certificate_map(void)
 {
@@ -576,19 +591,6 @@ static char *calculate_provisioning_session_hash(OpenAPI_provisioning_session_t 
     provisioning_session_hashed = calculate_hash(provisioning_session_to_hash);
     cJSON_free(provisioning_session_to_hash);
     return provisioning_session_hashed;
-}
-
-static char *calculate_service_access_information_hash(OpenAPI_service_access_information_resource_t *service_access_information)
-{
-    cJSON *service_access_info = NULL;
-    char *service_access_information_to_hash;
-    char *service_access_information_hashed = NULL;
-    service_access_info = OpenAPI_service_access_information_resource_convertToJSON(service_access_information);
-    service_access_information_to_hash = cJSON_Print(service_access_info);
-    cJSON_Delete(service_access_info);
-    service_access_information_hashed = calculate_hash(service_access_information_to_hash);
-    cJSON_free(service_access_information_to_hash);
-    return service_access_information_hashed;
 }
 
 static int
@@ -670,6 +672,16 @@ tidy_relative_path_re(void)
         ogs_free(relative_path_re);
         relative_path_re = NULL;
     }
+}
+
+static int
+free_ogs_hash_entry(void *rec, const void *key, int klen, const void *value)
+{
+    free_ogs_hash_context_t *fohc = (free_ogs_hash_context_t*)rec;
+    fohc->value_free_fn((void*)value);
+    ogs_hash_set(fohc->hash, key, klen, NULL);
+    ogs_free((void*)key);
+    return 1;
 }
 
 /* vim:ts=8:sts=4:sw=4:expandtab:

--- a/src/5gmsaf/provisioning-session.h
+++ b/src/5gmsaf/provisioning-session.h
@@ -12,9 +12,11 @@ https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 #define MSAF_PROVISIONING_SESSION_H
 
 #include <regex.h>
+
+#include "sai-cache.h"
+
 #include "openapi/model/consumption_reporting_configuration.h"
 #include "openapi/model/content_hosting_configuration.h"
-#include "openapi/model/service_access_information_resource.h"
 #include "openapi/model/provisioning_session.h"
 #include "openapi/model/provisioning_session_type.h"
 #include "openapi/model/m1_media_entry_point.h"
@@ -36,12 +38,11 @@ typedef struct msaf_provisioning_session_s {
     char *externalApplicationId;
     OpenAPI_consumption_reporting_configuration_t *consumptionReportingConfiguration;
     OpenAPI_content_hosting_configuration_t *contentHostingConfiguration;
-    OpenAPI_service_access_information_resource_t *serviceAccessInformation;
+    msaf_sai_cache_t *sai_cache;
     struct {
         msaf_http_metadata_t provisioningSession;
         msaf_http_metadata_t consumptionReportingConfiguration;
         msaf_http_metadata_t contentHostingConfiguration;
-        msaf_http_metadata_t serviceAccessInformation;
     } httpMetadata;
     ogs_hash_t *certificate_map;          //Type: char* => n/a (just used as a set - external tool manages data)
     ogs_list_t application_server_states; //Type: msaf_application_server_state_ref_node_t*
@@ -55,6 +56,7 @@ typedef struct msaf_application_server_state_ref_node_s {
 } msaf_application_server_state_ref_node_t;
 
 extern msaf_provisioning_session_t *msaf_provisioning_session_create(const char *provisioning_session_type, const char *asp_id, const char *external_app_id);
+extern void msaf_provisioning_session_free(msaf_provisioning_session_t *provisioning_session);
 extern msaf_provisioning_session_t *msaf_provisioning_session_find_by_provisioningSessionId(const char *provisioningSessionId);
 extern cJSON *msaf_provisioning_session_get_json(const char *provisioning_session_id);
 

--- a/src/5gmsaf/sai-cache.c
+++ b/src/5gmsaf/sai-cache.c
@@ -1,0 +1,216 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: David Waring
+Copyright: (C) 2023 British Broadcasting Corporation
+
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "ogs-core.h"
+
+#include "openapi/model/service_access_information_resource.h"
+#include "hash.h"
+
+#include "sai-cache.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct msaf_sai_cache_key_s {
+    size_t key_len;
+    bool use_tls;
+    char authority[0]; /* actual length is dynamic */
+} msaf_sai_cache_key_t;
+
+static void _debug_key(const msaf_sai_cache_key_t *key, const char *prefix);
+static msaf_sai_cache_key_t *_msaf_sai_cache_make_key(bool tls, const char *authority);
+static msaf_sai_cache_entry_t *_msaf_sai_cache_find(msaf_sai_cache_t *cache, const msaf_sai_cache_key_t *key);
+
+msaf_sai_cache_t *msaf_sai_cache_new(void)
+{
+    ogs_hash_t *ret;
+
+    ret = ogs_hash_make();
+
+    ogs_debug("msaf_sai_cache_new() = %p", ret);
+
+    return (msaf_sai_cache_t*)ret;
+}
+
+void msaf_sai_cache_free(msaf_sai_cache_t *cache)
+{
+    if (!cache) return;
+    ogs_debug("msaf_sai_cache_free(%p)", cache);
+    msaf_sai_cache_clear(cache);
+    ogs_hash_destroy(cache);
+}
+
+bool msaf_sai_cache_add(msaf_sai_cache_t *cache, bool tls, const char *authority, const OpenAPI_service_access_information_resource_t *sai)
+{
+    msaf_sai_cache_entry_t *entry;
+    msaf_sai_cache_key_t *key;
+
+    ogs_assert(cache);
+
+    ogs_debug("msaf_sai_cache_add(%p, %s, \"%s\", %p)", cache, tls?"true":"false", authority, sai);
+
+    key = _msaf_sai_cache_make_key(tls, authority);
+    entry = _msaf_sai_cache_find(cache, key);
+    if (entry) {
+        /* replacing existing entry, free old one */
+        msaf_sai_cache_entry_free(entry);
+    }
+
+    ogs_hash_set(cache, key, key->key_len, msaf_sai_cache_entry_new(sai));
+    return true;
+}
+
+bool msaf_sai_cache_del(msaf_sai_cache_t *cache, bool tls, const char *authority)
+{
+    msaf_sai_cache_entry_t *entry;
+    msaf_sai_cache_key_t *key;
+
+    if (!cache) return false;
+
+    ogs_debug("msaf_sai_cache_del(%p, %s, \"%s\")", cache, tls?"true":"false", authority);
+
+    key = _msaf_sai_cache_make_key(tls, authority);
+
+    entry = _msaf_sai_cache_find(cache, key);
+
+    if (entry) {
+        msaf_sai_cache_entry_free(entry);
+        ogs_hash_set(cache, key, key->key_len, NULL);
+        ogs_free(key);
+        return true;
+    }
+
+    ogs_free(key);
+    return false;
+}
+
+const msaf_sai_cache_entry_t *msaf_sai_cache_find(msaf_sai_cache_t *cache, bool tls, const char *authority)
+{
+    msaf_sai_cache_key_t *key;
+    const msaf_sai_cache_entry_t *entry;
+
+    //ogs_debug("msaf_sai_cache_find(cache=%p, tls=%s, authority=\"%s\")", cache, tls?"true":"false", authority);
+    key = _msaf_sai_cache_make_key(tls, authority);
+    entry = (const msaf_sai_cache_entry_t*)_msaf_sai_cache_find(cache, key);
+    ogs_free(key);
+    return entry;
+}
+
+bool msaf_sai_cache_clear(msaf_sai_cache_t *cache)
+{
+    ogs_hash_index_t *it;
+
+    if (!cache) return false;
+
+    ogs_debug("msaf_sai_cache_clear(%p) [%i entries]", cache, ogs_hash_count(cache));
+    for (it = ogs_hash_first(cache); it; it = ogs_hash_next(it)) {
+        const msaf_sai_cache_key_t *key;
+        int key_len;
+        msaf_sai_cache_entry_t *entry;
+
+        ogs_hash_this(it, (const void **)&key, &key_len, (void**)(&entry));
+        _debug_key(key, "=");
+        ogs_debug("clear %p[%i]: %p", key, key_len, entry);
+        ogs_hash_set(cache, key, key_len, NULL);
+        ogs_free((msaf_sai_cache_key_t*)key);
+        msaf_sai_cache_entry_free(entry);
+    }
+    ogs_debug("Entries after clear = %i", ogs_hash_count(cache));
+
+    return true;
+}
+
+bool msaf_sai_cache_clear_authority(msaf_sai_cache_t *cache, bool tls, const char *authority)
+{
+    return msaf_sai_cache_del(cache, tls, authority);
+}
+
+msaf_sai_cache_entry_t *msaf_sai_cache_entry_new(const OpenAPI_service_access_information_resource_t *sai)
+{
+    msaf_sai_cache_entry_t *entry;
+    cJSON *sai_json;
+
+    entry = ogs_calloc(1, sizeof(*entry));
+    ogs_assert(entry);
+
+    sai_json = OpenAPI_service_access_information_resource_convertToJSON((OpenAPI_service_access_information_resource_t*)sai);
+    ogs_assert(sai_json);
+
+    entry->sai_body = cJSON_Print(sai_json);
+    cJSON_Delete(sai_json);
+
+    entry->hash = calculate_hash(entry->sai_body);
+
+    entry->generated = ogs_time_now();
+
+    return entry;
+}
+
+void msaf_sai_cache_entry_free(msaf_sai_cache_entry_t *entry)
+{
+    if (!entry) return;
+
+    if (entry->sai_body) cJSON_free(entry->sai_body);
+    if (entry->hash) ogs_free(entry->hash);
+
+    ogs_free(entry);
+}
+
+/**** Static functions ****/
+
+static msaf_sai_cache_key_t *_msaf_sai_cache_make_key(bool tls, const char *authority)
+{
+    msaf_sai_cache_key_t *key;
+    size_t key_len;
+
+    key_len = sizeof(*key)+strlen(authority)+1;
+    key = ogs_calloc(1, key_len);
+    ogs_assert(key);
+
+    key->key_len = key_len;
+    key->use_tls = tls;
+    strcpy(key->authority, authority);
+
+    return key;
+}
+
+static void _debug_key(const msaf_sai_cache_key_t *key, const char *prefix)
+{
+    ogs_debug("%s len=%zi, tls=%s, authority=\"%s\"", prefix, key->key_len, key->use_tls?"true":"false", key->authority);
+}
+
+static msaf_sai_cache_entry_t *_msaf_sai_cache_find(msaf_sai_cache_t *cache, const msaf_sai_cache_key_t *key)
+{
+    {
+        ogs_hash_index_t *it;
+        _debug_key(key,"*");
+        for (it = ogs_hash_first(cache); it; it = ogs_hash_next(it)) {
+            const msaf_sai_cache_key_t *hkey;
+            int key_len;
+            msaf_sai_cache_entry_t *entry;
+
+            ogs_hash_this(it, (const void**)&hkey, &key_len, (void **)&entry);
+            _debug_key(hkey,">");
+        }
+    }
+    return (msaf_sai_cache_entry_t*)ogs_hash_get(cache, key, key->key_len);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/5gmsaf/sai-cache.h
+++ b/src/5gmsaf/sai-cache.h
@@ -1,0 +1,52 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: David Waring
+Copyright: (C) 2023 British Broadcasting Corporation
+
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+#ifndef MSAF_SAI_CACHE_H
+#define MSAF_SAI_CACHE_H
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "ogs-core.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct OpenAPI_service_access_information_resource_s OpenAPI_service_access_information_resource_t;
+
+typedef struct msaf_sai_cache_entry_s {
+    char *sai_body;
+    char *hash;
+    ogs_time_t generated;
+} msaf_sai_cache_entry_t;
+
+typedef ogs_hash_t msaf_sai_cache_t;
+
+msaf_sai_cache_t *msaf_sai_cache_new(void);
+void msaf_sai_cache_free(msaf_sai_cache_t*);
+bool msaf_sai_cache_add(msaf_sai_cache_t*, bool tls, const char *authority, const OpenAPI_service_access_information_resource_t *);
+bool msaf_sai_cache_del(msaf_sai_cache_t*, bool tls, const char *authority);
+const msaf_sai_cache_entry_t *msaf_sai_cache_find(msaf_sai_cache_t*, bool tls, const char *authority);
+bool msaf_sai_cache_clear(msaf_sai_cache_t*);
+bool msaf_sai_cache_clear_authority(msaf_sai_cache_t*, bool tls, const char *authority);
+
+msaf_sai_cache_entry_t *msaf_sai_cache_entry_new(const OpenAPI_service_access_information_resource_t *);
+void msaf_sai_cache_entry_free(msaf_sai_cache_entry_t*);
+
+#ifdef __cplusplus
+}
+#endif
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+
+#endif /* MSAF_SAI_CACHE_H */

--- a/src/5gmsaf/service-access-information.c
+++ b/src/5gmsaf/service-access-information.c
@@ -12,37 +12,132 @@ https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "ogs-core.h"
+
 #include "context.h"
 #include "utilities.h"
 #include "provisioning-session.h"
 
+#include "openapi/model/service_access_information_resource.h"
+
+#include "service-access-information.h"
+
 OpenAPI_service_access_information_resource_t *
-msaf_context_service_access_information_create(const char *provisioning_session_id, OpenAPI_list_t *entry_points)
+msaf_context_service_access_information_create(msaf_provisioning_session_t *provisioning_session, bool is_tls, const char *svr_hostname)
 {
-    OpenAPI_service_access_information_resource_streaming_access_t *streaming_access
-        = OpenAPI_service_access_information_resource_streaming_access_create(entry_points, NULL);
-    OpenAPI_service_access_information_resource_t *service_access_information
-        = OpenAPI_service_access_information_resource_create(
-                msaf_strdup(provisioning_session_id),
-                OpenAPI_provisioning_session_type_DOWNLINK, streaming_access, NULL, NULL,
-                NULL, NULL,NULL);
+    OpenAPI_service_access_information_resource_t *service_access_information;
+    OpenAPI_service_access_information_resource_streaming_access_t *streaming_access;
+    //msaf_configuration_t *config = &msaf_self()->config;
+    OpenAPI_service_access_information_resource_client_consumption_reporting_configuration_t *ccrc = NULL;
+    OpenAPI_list_t *entry_points = NULL;
+
+    /* streaming entry points */
+    ogs_debug("Adding streams to ServiceAccessInformation [%s]", provisioning_session->provisioningSessionId);
+    if (provisioning_session->contentHostingConfiguration) {
+        OpenAPI_lnode_t *node;
+        OpenAPI_list_for_each(provisioning_session->contentHostingConfiguration->distribution_configurations, node) {
+            OpenAPI_distribution_configuration_t *dist_conf = node->data;
+	    if (dist_conf->entry_point && dist_conf->base_url) {
+		OpenAPI_m5_media_entry_point_t *m5_entry;
+	        char *url;
+                OpenAPI_list_t *m5_profiles = NULL;
+
+		if (dist_conf->entry_point->profiles) {
+		    OpenAPI_lnode_t *prof_node;
+		    m5_profiles = OpenAPI_list_create();
+		    OpenAPI_list_for_each(dist_conf->entry_point->profiles, prof_node) {
+			OpenAPI_list_add(m5_profiles, ogs_strdup(prof_node->data));
+		    }
+		}
+
+		url = ogs_msprintf("%s%s", dist_conf->base_url, dist_conf->entry_point->relative_path);
+		m5_entry = OpenAPI_m5_media_entry_point_create(url, ogs_strdup(dist_conf->entry_point->content_type), m5_profiles);
+		ogs_assert(m5_entry);
+		if (!entry_points) entry_points = OpenAPI_list_create();
+		OpenAPI_list_add(entry_points, m5_entry);
+	    }
+	}
+    }
+    streaming_access = OpenAPI_service_access_information_resource_streaming_access_create(entry_points, NULL);
+
+    /* client consumption reporting configuration */
+    if (provisioning_session->consumptionReportingConfiguration) {
+        OpenAPI_list_t *ccrc_svr_list;
+
+        ogs_debug("Adding clientConsumptionReportingConfiguration to ServiceAccessInformation [%s]",
+                  provisioning_session->provisioningSessionId);
+
+        ccrc_svr_list = OpenAPI_list_create();
+	ogs_assert(ccrc_svr_list);
+        OpenAPI_list_add(ccrc_svr_list, ogs_msprintf("http%s://%s/3gpp-m5/v2/", is_tls?"s":"", svr_hostname));
+        ccrc = OpenAPI_service_access_information_resource_client_consumption_reporting_configuration_create(
+                    provisioning_session->consumptionReportingConfiguration->is_reporting_interval,
+                    provisioning_session->consumptionReportingConfiguration->reporting_interval,
+                    ccrc_svr_list,
+                    provisioning_session->consumptionReportingConfiguration->is_location_reporting?
+                        provisioning_session->consumptionReportingConfiguration->location_reporting:
+                        0,
+                    provisioning_session->consumptionReportingConfiguration->is_access_reporting,
+                    provisioning_session->consumptionReportingConfiguration->access_reporting,
+                    provisioning_session->consumptionReportingConfiguration->is_sample_percentage?
+                        provisioning_session->consumptionReportingConfiguration->sample_percentage:
+                        100.0
+                    );
+        ogs_assert(ccrc);
+    }
+
+    /* Create SAI */
+    service_access_information = OpenAPI_service_access_information_resource_create(
+                msaf_strdup(provisioning_session->provisioningSessionId),
+                OpenAPI_provisioning_session_type_DOWNLINK,
+                streaming_access,
+                ccrc /* client_consumption_reporting_configuration */,
+                NULL /* dynamic_policy */,
+                NULL /* client_metrics_reporting */,
+                NULL /* network_assistance_configuration */,
+                NULL /* client_edge_resources */);
+    ogs_assert(service_access_information);
+
     return service_access_information;
 }
 
-cJSON *msaf_context_retrieve_service_access_information(char *provisioning_session_id)
+const msaf_sai_cache_entry_t *msaf_context_retrieve_service_access_information(const char *provisioning_session_id, bool is_tls, const char *authority)
 {
-    msaf_provisioning_session_t *provisioning_session_context = NULL;
+    msaf_provisioning_session_t *provisioning_session_context;
+    const msaf_sai_cache_entry_t *sai_entry = NULL;
+
     provisioning_session_context = msaf_provisioning_session_find_by_provisioningSessionId(provisioning_session_id);
     if (provisioning_session_context == NULL){
         ogs_error("Couldn't find the Provisioning Session ID [%s]", provisioning_session_id);    
         return NULL;
     }
-    if (provisioning_session_context->serviceAccessInformation == NULL){
-       ogs_error("The provisioning Session [%s] does not have an associated Service Access Information", provisioning_session_id);
-       return NULL;
+
+    if (!provisioning_session_context->sai_cache) {
+        provisioning_session_context->sai_cache = msaf_sai_cache_new();
+    } else {
+        sai_entry = msaf_sai_cache_find(provisioning_session_context->sai_cache, is_tls, authority);
     }
-    cJSON *service_access_information = OpenAPI_service_access_information_resource_convertToJSON(provisioning_session_context->serviceAccessInformation);
-    return service_access_information;
+
+    if (!sai_entry) {
+	OpenAPI_service_access_information_resource_t *sai;
+
+        ogs_debug("Create new SAI for http%s://%s on provisioning session [%s]", is_tls?"s":"", authority, provisioning_session_id);
+
+	sai = msaf_context_service_access_information_create(provisioning_session_context, is_tls, authority);
+	msaf_sai_cache_add(provisioning_session_context->sai_cache, is_tls, authority, sai);
+	OpenAPI_service_access_information_resource_free(sai);
+	sai_entry = msaf_sai_cache_find(provisioning_session_context->sai_cache, is_tls, authority);
+    } else {
+        ogs_debug("Found existing SAI cache entry");
+    }
+
+    if (sai_entry == NULL){
+       ogs_error("The provisioning Session [%s] does not have an associated Service Access Information", provisioning_session_id);
+    }
+
+    return sai_entry;
 }
 
-
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/5gmsaf/service-access-information.h
+++ b/src/5gmsaf/service-access-information.h
@@ -24,13 +24,14 @@ https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 #include "openapi/model/service_access_information_resource.h"
 #include "provisioning-session.h"
 #include "application-server-context.h"
+#include "sai-cache.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern OpenAPI_service_access_information_resource_t *msaf_context_service_access_information_create(const char *provisioning_session_id, OpenAPI_list_t *entry_points);
-extern cJSON *msaf_context_retrieve_service_access_information(char *provisioning_session_id);
+OpenAPI_service_access_information_resource_t *msaf_context_service_access_information_create(msaf_provisioning_session_t *provisioning_session, bool is_tls, const char *svr_hostname);
+const msaf_sai_cache_entry_t *msaf_context_retrieve_service_access_information(const char *provisioning_session_id, bool is_tls, const char *authority);
 
 #ifdef __cplusplus
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,10 @@
+# License: 5G-MAG Public License (v1.0)
+# Author: David Waring
+# Copyright: (C) 2023 British Broadcasting Corporation
+#
+# For full license terms please see the LICENSE file distributed with this
+# program. If this file is missing then the license can be retrieved from
+# https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+#
+
+subdir('msaf')

--- a/tests/msaf/abts-main.c
+++ b/tests/msaf/abts-main.c
@@ -1,0 +1,62 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Copyright: (C) 2022 British Broadcasting Corporation
+
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+#include "test-app.h"
+#include "af/init.h"
+#include "af/sbi-path.h"
+
+#include "tests.h"
+
+int __msaf_log_domain;
+
+static void terminate(void)
+{
+    ogs_msleep(50);
+    af_terminate();
+
+    test_child_terminate();
+    app_terminate();
+
+    test_5gc_final();
+    ogs_app_terminate();
+}
+
+static void initialize(const char *const argv[])
+{
+    int rv;
+    rv = ogs_app_initialize(NULL, NULL, argv);
+    ogs_assert(rv == OGS_OK);
+    test_5gc_init();
+
+    ogs_log_install_domain(&__msaf_log_domain, "test-msaf", ogs_core()->log.level);
+
+    rv = app_initialize(argv);
+    ogs_assert(rv == OGS_OK);
+
+    rv = af_initialize();
+    ogs_assert(rv == OGS_OK);
+
+    /* ogs_log_set_mask_level(NULL, OGS_LOG_DEBUG); */ /* Uncomment to force DEBUG output in unit test */
+}
+
+int main(int argc, const char *const argv[])
+{
+    int i;
+    abts_suite *suite = NULL;
+
+    atexit(terminate);
+    test_app_run(argc, argv, "sample.yaml", initialize);
+
+    suite = tests_run(suite);
+
+    return abts_report(suite);
+}
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/tests/msaf/meson.build
+++ b/tests/msaf/meson.build
@@ -1,0 +1,32 @@
+# License: 5G-MAG Public License (v1.0)
+# Copyright: (C) 2022 British Broadcasting Corporation
+#
+# For full license terms please see the LICENSE file distributed with this
+# program. If this file is missing then the license can be retrieved from
+# https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+
+libtest5gc_dep = open5gs_project.get_variable('libtest5gc_dep')
+testunit_core_cc_flags = open5gs_project.get_variable('testunit_core_cc_flags')
+sbi_openapi_inc = open5gs_project.get_variable('libsbi_openapi_model_inc')
+srcinc = open5gs_project.get_variable('srcinc')
+
+test_msaf_sources = files('''
+    abts-main.c
+
+    sai-cache-test.c
+    sai-cache-test.h
+
+    tests.c
+    tests.h
+'''.split())
+
+test_msaf_exe = executable('test-msaf',
+    sources : test_msaf_sources,
+    c_args : testunit_core_cc_flags,
+    include_directories : [srcinc, msaf_include, sbi_openapi_inc],
+    dependencies : [libtest5gc_dep, libmsaf_dep])
+
+test('test-msaf',
+    test_msaf_exe,
+    is_parallel : false,
+    suite: 'app')

--- a/tests/msaf/sai-cache-test.c
+++ b/tests/msaf/sai-cache-test.c
@@ -1,0 +1,166 @@
+/*
+ * License: 5G-MAG Public License (v1.0)
+ * Copyright: (C) 2023 British Broadcasting Corporation
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+/* Open5GS includes */
+#include "test-common.h"
+
+/* MSAF includes */
+#include "sai-cache.h"
+#include "openapi/model/service_access_information_resource.h"
+
+/* Test includes */
+#include "sai-cache-test.h"
+
+#define ABTS_PTR_NULL(a, b) ABTS_PTR_EQUAL(a, b, NULL)
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* ifdef __cplusplus */
+
+/* Create and tidy up a cache */
+static void test_sai_cache_create(abts_case *tc, void *data)
+{
+    msaf_sai_cache_t *cache;
+
+    cache = msaf_sai_cache_new();
+    ABTS_PTR_NOTNULL(tc, cache);
+
+    *((msaf_sai_cache_t**)data) = cache;
+}
+
+static void test_sai_cache_add(abts_case *tc, void *data)
+{
+    OpenAPI_service_access_information_resource_t *sai;
+    OpenAPI_service_access_information_resource_streaming_access_t *streams = NULL;
+    OpenAPI_service_access_information_resource_network_assistance_configuration_t *nac = NULL;
+    OpenAPI_list_t *entry_points;
+    OpenAPI_list_t *dash_profiles;
+    OpenAPI_list_t *nac_addresses;
+    msaf_sai_cache_t *cache = *((msaf_sai_cache_t**)data);
+    ABTS_PTR_NOTNULL(tc, cache);
+
+    dash_profiles = OpenAPI_list_create();
+    ABTS_PTR_NOTNULL(tc, dash_profiles);
+    OpenAPI_list_add(dash_profiles, ogs_strdup("urn:mpeg:dash:profile:isoff-live:2011"));
+
+    entry_points = OpenAPI_list_create();
+    ABTS_PTR_NOTNULL(tc, entry_points);
+    OpenAPI_list_add(entry_points, OpenAPI_m5_media_entry_point_create(ogs_strdup("http://as.exmaple.com/m4d/manifest.mpd"), ogs_strdup("application/dash+xml"), dash_profiles));
+    OpenAPI_list_add(entry_points, OpenAPI_m5_media_entry_point_create(ogs_strdup("http://as.exmaple.com/m4d/manifest.m3u8"), ogs_strdup("application/vnd.apple.mpegurl"), NULL));
+
+    streams = OpenAPI_service_access_information_resource_streaming_access_create(entry_points, NULL);
+    ABTS_PTR_NOTNULL(tc, streams);
+
+    nac_addresses = OpenAPI_list_create();
+    ABTS_PTR_NOTNULL(tc, nac_addresses);
+    OpenAPI_list_add(nac_addresses, ogs_strdup("http://af.example.com:9876/3gpp-m5/v2/"));
+
+    nac = OpenAPI_service_access_information_resource_network_assistance_configuration_create(nac_addresses);
+    ABTS_PTR_NOTNULL(tc, nac);
+
+    sai = OpenAPI_service_access_information_resource_create(ogs_strdup("Provisioning-Session-Id"), OpenAPI_provisioning_session_type_DOWNLINK, streams, NULL, NULL, NULL, nac, NULL);
+    ABTS_PTR_NOTNULL(tc, sai);
+
+    ABTS_TRUE(tc, msaf_sai_cache_add(cache, true, "af.example.com:443", sai));
+
+    OpenAPI_service_access_information_resource_free(sai);
+}
+
+static void test_sai_cache_find_exists(abts_case *tc, void *data)
+{
+    const msaf_sai_cache_entry_t *entry;
+    msaf_sai_cache_t *cache = *((msaf_sai_cache_t**)data);
+    ABTS_PTR_NOTNULL(tc, cache);
+
+    entry = msaf_sai_cache_find(cache, true, "af.example.com:443");
+    ABTS_PTR_NOTNULL(tc, entry);
+}
+
+static void test_sai_cache_find_not_exists1(abts_case *tc, void *data)
+{
+    /* wrong TLS flag */
+    const msaf_sai_cache_entry_t *entry;
+    msaf_sai_cache_t *cache = *((msaf_sai_cache_t**)data);
+    ABTS_PTR_NOTNULL(tc, cache);
+
+    entry = msaf_sai_cache_find(cache, false, "af.example.com:443");
+    ABTS_PTR_NULL(tc, entry);
+}
+
+static void test_sai_cache_find_not_exists2(abts_case *tc, void *data)
+{
+    /* wrong authority */
+    const msaf_sai_cache_entry_t *entry;
+    msaf_sai_cache_t *cache = *((msaf_sai_cache_t**)data);
+    ABTS_PTR_NOTNULL(tc, cache);
+
+    entry = msaf_sai_cache_find(cache, true, "not-af.example.com:443");
+    ABTS_PTR_NULL(tc, entry);
+}
+
+static void test_sai_cache_clear(abts_case *tc, void *data)
+{
+    msaf_sai_cache_t *cache = *((msaf_sai_cache_t**)data);
+    ABTS_PTR_NOTNULL(tc, cache);
+
+    msaf_sai_cache_clear(cache);
+}
+
+static void test_sai_cache_find_removed(abts_case *tc, void *data)
+{
+    const msaf_sai_cache_entry_t *entry;
+    msaf_sai_cache_t *cache = *((msaf_sai_cache_t**)data);
+    ABTS_PTR_NOTNULL(tc, cache);
+
+    entry = msaf_sai_cache_find(cache, true, "af.example.com:443");
+    ABTS_PTR_NULL(tc, entry);
+}
+
+static void test_sai_cache_free(abts_case *tc, void *data)
+{   
+    msaf_sai_cache_t *cache = *((msaf_sai_cache_t**)data);
+
+    ABTS_PTR_NOTNULL(tc, cache);
+
+    msaf_sai_cache_free(cache);
+}
+
+static struct {
+    void (*func)(abts_case *tc, void *data);
+} test_cases[] = {
+    {test_sai_cache_create},
+    {test_sai_cache_add},
+    {test_sai_cache_find_exists},
+    {test_sai_cache_find_not_exists1},
+    {test_sai_cache_find_not_exists2},
+    {test_sai_cache_clear},
+    {test_sai_cache_find_removed},
+    {test_sai_cache_free}
+};
+
+abts_suite *test_sai_cache(abts_suite *suite)
+{
+    int i;
+    msaf_sai_cache_t *cache = NULL;
+
+    suite = ADD_SUITE(suite)
+
+    for (i=0; i<(sizeof(test_cases)/sizeof(test_cases[0])); i++) {
+        abts_run_test(suite, test_cases[i].func, &cache);
+    }
+
+    return suite;
+}
+
+#ifdef __cplusplus
+}
+#endif /* ifdef __cplusplus */
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/tests/msaf/sai-cache-test.h
+++ b/tests/msaf/sai-cache-test.h
@@ -1,0 +1,29 @@
+/*
+ * License: 5G-MAG Public License (v1.0)
+ * Copyright: (C) 2023 British Broadcasting Corporation
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+#ifndef _TESTS_MSAF_SAI_CACHE_TEST_H
+#define _TESTS_MSAF_SAI_CACHE_TEST_H
+
+/* Open5GS includes */
+#include "test-common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* ifdef __cplusplus */
+
+abts_suite *test_sai_cache(abts_suite *suite);
+
+#ifdef __cplusplus
+}
+#endif /* ifdef __cplusplus */
+
+#endif /* ifndef _TESTS_MSAF_SAI_CACHE_TEST_H */
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/tests/msaf/tests.c
+++ b/tests/msaf/tests.c
@@ -1,0 +1,37 @@
+/*
+ * License: 5G-MAG Public License (v1.0)
+ * Copyright: (C) 2023 British Broadcasting Corporation
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+/* Open5GS includes */
+#include "test-common.h"
+#include "af/sbi-path.h"
+
+/* Unit test includes */
+#include "sai-cache-test.h"
+
+#include "tests.h"
+
+static struct {
+    abts_suite *(*func)(abts_suite *suite);
+} alltests[] = {
+    {test_sai_cache}
+};
+
+abts_suite *tests_run(abts_suite *suite)
+{
+    int i;
+
+    for (i=0; i<(sizeof(alltests)/sizeof(alltests[0])); i++) {
+	suite = alltests[i].func(suite);
+    }
+
+    return suite;
+}
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/tests/msaf/tests.h
+++ b/tests/msaf/tests.h
@@ -1,0 +1,29 @@
+/*
+ * License: 5G-MAG Public License (v1.0)
+ * Copyright: (C) 2023 British Broadcasting Corporation
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+#ifndef _TESTS_MSAF_TESTS_H
+#define _TESTS_MSAF_TESTS_H
+
+/* Open5GS includes */
+#include "test-common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* ifdef __cplusplus */
+
+abts_suite *tests_run(abts_suite *suite);
+
+#ifdef __cplusplus
+}
+#endif /* ifdef __cplusplus */
+
+#endif /* ifndef _TESTS_MSAF_TESTS_H */
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */


### PR DESCRIPTION
This adds the `clientConsumptionReportingConfiguration` field to the Service Access Information (SAI) response at interface reference point M5 if a *ConsumptionReportingConfiguration* is set on the Provisioning Session.

The `ServiceAccessInformation.clientConsumptionReportingConfiguration.serverAddresses` contains a list of M5 API access URLs. To guarantee that the UE that has requested the SAI can also access the Consumption Reporting interface (on the same interface at reference point M5), this list is set to contain server addresses based on the `Host` and access protocols used to request the Service Access Information. This means that responses for requests using different URL protocols and authorities will be given responses with different server addresses. To make this efficient and to implement the responses for requests with `If-None-Match` and/or `If-Modified-Since` headers, each SAI response is cached along with its initial creation time and `ETag` value. These cached responses are now held in a `sai_cache` attached to each internal `msaf_provisioning_session_t` instance. Any internal Application Function operation that will modify the output of the SAI response will need to invalidate this cache in order for the next SAI request at M5 to regenerate the new SAI contents. This is done by calling `msaf_sai_cache_clear()` and passing the `sai_cache` field from the provisioning session structure.

Closes #93 