### PR TITLE
Feature: Add M5 ConsumptionReporting API

### DIFF
--- a/src/5gmsaf/context.c
+++ b/src/5gmsaf/context.c
@@ -97,6 +97,9 @@ void msaf_context_final(void)
     if (self->config.certificateManager)
         ogs_free(self->config.certificateManager);
  
+    if (self->config.data_collection_dir)
+        ogs_free(self->config.data_collection_dir);
+
     msaf_context_server_addr_remove_all();
 
     msaf_application_server_remove_all();
@@ -495,6 +498,8 @@ int msaf_context_parse_config(void)
                     /* handle config in sbi library */
                 } else if (!strcmp(msaf_key, "discovery")) {
                     /* handle config in sbi library */
+                } else if (!strcmp(msaf_key, "dataCollectionDir")) {
+                    self->config.data_collection_dir = msaf_strdup(ogs_yaml_iter_value(&msaf_iter));
                 } else
                     ogs_warn("unknown key `%s`", msaf_key);
             }

--- a/src/5gmsaf/context.h
+++ b/src/5gmsaf/context.h
@@ -68,6 +68,8 @@ typedef struct msaf_configuration_s {
     
     msaf_server_response_cache_control_t *server_response_cache_control;
     int  number_of_application_servers;
+
+    char *data_collection_dir;
 } msaf_configuration_t;
 
 typedef struct msaf_context_s {

--- a/src/5gmsaf/data-collection.c
+++ b/src/5gmsaf/data-collection.c
@@ -1,0 +1,120 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: David Waring
+Copyright: (C) 2023 British Broadcasting Corporation
+
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "ogs-core.h"
+
+#include "context.h"
+
+#include "data-collection.h"
+
+/*****************************************************
+ ***** Local declarations
+ *****************************************************/
+
+static bool ensure_directory(const char *path);
+static int open_data_store_file(const char *provisioning_session_id, const char *report_class, const char *client_id,
+                                const char *session_id, const char *report_time, const char *format);
+
+/*****************************************************
+ ***** Public functions
+ *****************************************************/
+
+bool msaf_data_collection_store(const char *provisioning_session_id, const char *report_class, const char *client_id,
+                                const char *session_id, const char *report_time, const char *format, const char *report_body)
+{
+    int fd;
+    size_t body_len;
+
+    fd = open_data_store_file(provisioning_session_id, report_class, client_id, session_id, report_time, format);
+    
+    if (fd < 0) {
+        return false;
+    }
+
+    body_len = strlen(report_body);
+
+    if (write(fd, report_body, body_len) != body_len) {
+        ogs_error("Failed to write %s data report: %s", report_class, strerror(errno));
+        return false;
+    }
+
+    return true;
+}
+
+/*****************************************************
+ ***** Private functions
+ *****************************************************/
+
+static bool ensure_directory(const char *path)
+{
+    struct stat statbuf;
+    bool ret = false;
+
+    if ((path[0] == '/' || path[0] == '.') && path[1] == '\0') return true;
+
+    if (!stat(path, &statbuf)) {
+        if ((statbuf.st_mode & S_IFMT) == S_IFDIR) {
+            ret = true;
+        }
+    } else {
+        /* path doesn't exist so ensure parent directory is present and try to create wanted directory */
+        char *path_copy = ogs_strdup(path); 
+        if (ensure_directory(dirname(path_copy)) && !mkdir(path, 0755)) {
+            ret = true;
+        }
+        ogs_free(path_copy);
+    }
+
+    return ret;
+}
+
+static int open_data_store_file(const char *provisioning_session_id, const char *report_class, const char *client_id,
+                                const char *session_id, const char *report_time, const char *format)
+{
+    int fd = -1;
+    char *filepath;
+    char *reportdir;
+    const char *report_root;
+
+    report_root = msaf_self()->config.data_collection_dir;
+    if (!report_root) return -1;
+
+    reportdir = ogs_msprintf("%s/%s/%s", report_root, provisioning_session_id, report_class);
+
+    if (!ensure_directory(reportdir)) {
+        ogs_error("Unable to create report directory %s", reportdir);
+        ogs_free(reportdir);
+        return -1;
+    }
+
+    filepath = ogs_msprintf("%s/%s%s%s_%s.%s", reportdir, client_id, session_id?"_":"", session_id?session_id:"", report_time, format);
+    ogs_free(reportdir);
+
+    fd = open(filepath, O_CREAT|O_WRONLY|O_EXCL, 0664);
+
+    if (fd < 0) {
+        ogs_error("Unable to create %s for writing: %s", filepath, strerror(errno));
+    }
+
+    ogs_free(filepath);
+
+    return fd;
+}
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/src/5gmsaf/data-collection.h
+++ b/src/5gmsaf/data-collection.h
@@ -1,0 +1,43 @@
+/*
+License: 5G-MAG Public License (v1.0)
+Author: David Waring
+Copyright: (C) 2023 British Broadcasting Corporation
+
+For full license terms please see the LICENSE file distributed with this
+program. If this file is missing then the license can be retrieved from
+https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+ */
+
+#ifndef DATA_COLLECTION_H
+#define DATA_COLLECTION_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Store a Data Collection report
+ *
+ * @param[in] provisioning_session_id The provisioning session id to record the report under.
+ * @param[in] report_class The class of this report, e.g. "metrics_report_<id>" or "consumption_report".
+ * @param[in] client_id The Client ID to record this report against.
+ * @param[in] session_id The session ID to record this report against. Can be @c NULL if there is no session id.
+ * @param[in] report_time The report date-time in RFC3339 format.
+ * @param[in] format The file format for the body (i.e. the file extension "json" or "xml").
+ * @param[in] report_body The body of the report to store.
+ *
+ * @return @c true is the report was successfully stored or \c false if storage failed.
+ */
+bool msaf_data_collection_store(const char *provisioning_session_id, const char *report_class, const char *client_id,
+                                const char *session_id, const char *report_time, const char *format, const char *report_body);
+
+#ifdef __cplusplus
+}
+#endif
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */
+
+#endif /* ifndef DATA_COLLECTION_H */

--- a/src/5gmsaf/generator-5gmsaf
+++ b/src/5gmsaf/generator-5gmsaf
@@ -29,7 +29,7 @@ scriptdir=`cd "$scriptdir"; pwd`
 
 # Command line option defaults
 default_branch='REL-17'
-default_apis="TS26512_M1_ProvisioningSessions TS26512_M1_ContentHostingProvisioning TS26512_M1_ServerCertificatesProvisioning TS26512_M1_ContentProtocolsDiscovery TS26512_M1_ConsumptionReportingProvisioning M3_ContentHostingProvisioning M3_ServerCertificatesProvisioning TS26512_M5_ServiceAccessInformation Maf_Management"
+default_apis="TS26512_M1_ProvisioningSessions TS26512_M1_ContentHostingProvisioning TS26512_M1_ServerCertificatesProvisioning TS26512_M1_ContentProtocolsDiscovery TS26512_M1_ConsumptionReportingProvisioning M3_ContentHostingProvisioning M3_ServerCertificatesProvisioning TS26512_M5_ServiceAccessInformation TS26512_M5_ConsumptionReporting Maf_Management"
 
 # Parse command line arguments
 ARGS=`getopt -n "$scriptname" -o 'a:b:hM:' -l 'api:,branch:,help,model-deps:' -s sh -- "$@"`

--- a/src/5gmsaf/meson.build
+++ b/src/5gmsaf/meson.build
@@ -147,6 +147,7 @@ executable('open5gs-msafd',
 meson.add_install_script(python3_exe, '-c', mkdir_p.format(open5gs_sysconfdir))
 conf_configuration = configuration_data()
 conf_configuration.set('default-certmgr', get_option('prefix') / self_signed_certmgr_runtime)
+conf_configuration.set('data-collection-dir', get_option('prefix') / get_option('localstatedir') / 'log' / 'open5gs' / 'reports')
 foreach conf_file : msaf_config_source
     gen = configure_file(input : conf_file + '.in', configuration : conf_configuration, output : conf_file)
     meson.add_install_script(python3_exe, '-c', install_conf.format(gen, open5gs_sysconfdir))

--- a/src/5gmsaf/meson.build
+++ b/src/5gmsaf/meson.build
@@ -34,6 +34,8 @@ libmsaf_dist_sources = files('''
     consumption-report-configuration.h
     context.c
     context.h
+    data-collection.c
+    data-collection.h
     event.c
     event.h
     hash.h

--- a/src/5gmsaf/msaf.yaml.in
+++ b/src/5gmsaf/msaf.yaml.in
@@ -194,6 +194,7 @@ msaf:
         m1ContentProtocols: 86400
         m1ConsumptionReportingConfiguration: 60
         m5ServiceAccessInformation: 60
+    dataCollectionDir: @data-collection-dir@
 #
 # nrf:
 #


### PR DESCRIPTION
This adds the ConsumptionReporting API to the interface at reference point M5.

This is a simple API with only one `POST` operation to allow a 5GMS Aware App to submit a consumption report. The App's consumption reporting is controlled using the `clientConsumptionReportingConfiguration` returned in the `ServiceAccessInformation` (see #93).

This PR adds that `POST` operation along with `OPTIONS` operations for both the service access information and consumption reporting APIs on the interface at reference point M5.

This also introduces a Data Collection function to store the data into a data collection reports directory. The directory is controlled by the `msaf.dataCollectionDir` configuration parameter in the YAML configuration file. If not present in the configuration then no reports will be stored. The `msaf_data_collection_store()` function (defined in `data-collection.h`) will store a report in a sub-directory underneath the configured `msaf.dataCollectionDir`. Sub-directories are created as needed. This function will log an error and return false if the directory path cannot be created, if the report file already exists or if the report file cannot be created. This function should be useful for #90.

Closes #89