### PR TITLE
Fix: ConsumptionReportConfiguration validation and accessReporting field

### DIFF
--- a/src/5gmsaf/consumption-report-configuration.c
+++ b/src/5gmsaf/consumption-report-configuration.c
@@ -89,6 +89,33 @@ bool msaf_consumption_report_configuration_deregister(msaf_provisioning_session_
     return true;
 }
 
+OpenAPI_consumption_reporting_configuration_t *msaf_consumption_report_configuration_parseJSON(cJSON *json /* [no-transfer, not-null] */, const char **err_out /* [out, not-null] */)
+{
+    OpenAPI_consumption_reporting_configuration_t *crc;
+
+    *err_out = NULL;
+
+    crc = OpenAPI_consumption_reporting_configuration_parseFromJSON(json);
+    if (!crc) {
+        *err_out = "Failed to convert JSON to a ConsumptionReportingConfiguration";
+        return NULL;
+    }
+
+    if (crc->is_sample_percentage && (crc->sample_percentage < 0.0 || crc->sample_percentage > 100.0)) {
+        *err_out = "Bad value: samplePercentage out of range";
+        OpenAPI_consumption_reporting_configuration_free(crc);
+        return NULL;
+    }
+
+    if (crc->is_reporting_interval && crc->reporting_interval <= 0) {
+        *err_out = "Bad value: reportingInterval must be greater than 0";
+        OpenAPI_consumption_reporting_configuration_free(crc);
+        return NULL;
+    }
+
+    return crc;
+}
+
 cJSON *msaf_consumption_report_configuration_json(msaf_provisioning_session_t *session /* [no-transfer, not-null] */)
 {
     cJSON *json;

--- a/src/5gmsaf/consumption-report-configuration.h
+++ b/src/5gmsaf/consumption-report-configuration.h
@@ -24,6 +24,8 @@ extern bool msaf_consumption_report_configuration_update(msaf_provisioning_sessi
                                                 OpenAPI_consumption_reporting_configuration_t *config /* [transfer, not-null] */);
 extern bool msaf_consumption_report_configuration_deregister(msaf_provisioning_session_t *session /* [no-transfer, not-null] */);
 
+extern OpenAPI_consumption_reporting_configuration_t *msaf_consumption_report_configuration_parseJSON(
+                                                cJSON *json /* [no-transfer, not-null] */, const char **err_out /* [out, not-null] */);
 extern cJSON *msaf_consumption_report_configuration_json(msaf_provisioning_session_t *session /* [no-transfer, not-null] */);
 extern char *msaf_consumption_report_configuration_body(msaf_provisioning_session_t *session /* [no-transfer, not-null] */);
 extern time_t msaf_consumption_report_configuration_last_modified(

--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -489,13 +489,14 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                     ogs_free(err);
                                 } else {
                                     OpenAPI_consumption_reporting_configuration_t *report_config;
+                                    const char *parse_err = NULL;
 
-                                    report_config = OpenAPI_consumption_reporting_configuration_parseFromJSON(json);
+                                    report_config = msaf_consumption_report_configuration_parseJSON(json, &parse_err);
                                     cJSON_Delete(json);
 
                                     if (!report_config) {
                                         char *err;
-                                        err = ogs_msprintf("Bad ConsumptionReportingConfiguration for provisioning session [%s]", message->h.resource.component[1]);
+                                        err = ogs_msprintf("Bad ConsumptionReportingConfiguration for provisioning session [%s]: %s", message->h.resource.component[1], parse_err);
                                         ogs_error("%s", err);
                                         ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Bad request.", err, NULL, api, app_meta));
                                         ogs_free(err);
@@ -1002,10 +1003,12 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                     ogs_free(err);
                                 } else {
                                     OpenAPI_consumption_reporting_configuration_t *config;
-                                    config = OpenAPI_consumption_reporting_configuration_parseFromJSON(json);
+                                    const char *parse_err = NULL;
+
+                                    config = msaf_consumption_report_configuration_parseJSON(json, &parse_err);
                                     if (!config) {
                                         char *err = NULL;
-                                        err = ogs_msprintf("Bad request body while updating ConsumptionReportingConfiguration for Provisioining Session [%s].", message->h.resource.component[1]);
+                                        err = ogs_msprintf("Bad request body while updating ConsumptionReportingConfiguration for Provisioining Session [%s]: %s", message->h.resource.component[1], parse_err);
                                         ogs_error("%s", err);
                                         ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Bad request.", err, NULL, api, app_meta));
                                         ogs_free(err);

--- a/src/5gmsaf/service-access-information.c
+++ b/src/5gmsaf/service-access-information.c
@@ -78,8 +78,10 @@ msaf_context_service_access_information_create(msaf_provisioning_session_t *prov
                     provisioning_session->consumptionReportingConfiguration->is_location_reporting?
                         provisioning_session->consumptionReportingConfiguration->location_reporting:
                         0,
-                    provisioning_session->consumptionReportingConfiguration->is_access_reporting,
-                    provisioning_session->consumptionReportingConfiguration->access_reporting,
+                    true, /* TS 26.512 Table 11.2.3.1-1 says the accessReporting field is mandatory */
+                    provisioning_session->consumptionReportingConfiguration->is_access_reporting?
+                        provisioning_session->consumptionReportingConfiguration->access_reporting:
+                        0,
                     provisioning_session->consumptionReportingConfiguration->is_sample_percentage?
                         provisioning_session->consumptionReportingConfiguration->sample_percentage:
                         100.0


### PR DESCRIPTION
Adds some field validation to the AF to stop the python tool rejecting things that the AF has accepted.

Forces the output of the `accessReporting` field in M5 Service Access Information.

Closes #98, closes #99 