### PR TITLE
Bug-fix: Use canonical domain in publication dirs

### DIFF
--- a/tools/python3/m1_sync_config.py
+++ b/tools/python3/m1_sync_config.py
@@ -436,8 +436,9 @@ async def dump_m8_files(m1: M1Session, stream_map: dict, vod_streams: List[dict]
             if ps_id not in vod_ps_ids:
                 m8_config['serviceList'] += [{'provisioningSessionId': ps_id, 'name': chc['name']}]
             for dc in chc['distributionConfigurations']:
-                if 'domainNameAlias' in dc:
-                    publish_dirs.add(os.path.join(config.get("af-sync", "docroot"), dc['domainNameAlias']))
+                for hostfield in ['canonicalDomainName', 'domainNameAlias']:
+                    if hostfield in dc:
+                        publish_dirs.add(os.path.join(config.get("af-sync", "docroot"), dc[hostfield]))
         else:
             log_error(f"Provisioning Session {ps_id} was not initialised correctly: omitting")
     for vod in vod_streams:


### PR DESCRIPTION
Adds the *canonicalDomainName* field values, from ContentHostingConfigurations, to the list of domains to publish the `m8.json` file to.

This is a fix for an issue noticed on the Linode VM.

Closes #101 