### PR TITLE
Feature: Add M5 MetricsReporting API

### DIFF
--- a/src/5gmsaf/generator-5gmsaf
+++ b/src/5gmsaf/generator-5gmsaf
@@ -29,7 +29,7 @@ scriptdir=`cd "$scriptdir"; pwd`
 
 # Command line option defaults
 default_branch='REL-17'
-default_apis="TS26512_M1_ProvisioningSessions TS26512_M1_ContentHostingProvisioning TS26512_M1_ServerCertificatesProvisioning TS26512_M1_ContentProtocolsDiscovery TS26512_M1_ConsumptionReportingProvisioning M3_ContentHostingProvisioning M3_ServerCertificatesProvisioning TS26512_M5_ServiceAccessInformation TS26512_M5_ConsumptionReporting Maf_Management"
+default_apis="TS26512_M1_ProvisioningSessions TS26512_M1_ContentHostingProvisioning TS26512_M1_ServerCertificatesProvisioning TS26512_M1_ContentProtocolsDiscovery TS26512_M1_ConsumptionReportingProvisioning M3_ContentHostingProvisioning M3_ServerCertificatesProvisioning TS26512_M5_ServiceAccessInformation TS26512_M5_ConsumptionReporting Maf_Management TS26512_M5_MetricsReporting"
 
 # Parse command line arguments
 ARGS=`getopt -n "$scriptname" -o 'a:b:hM:' -l 'api:,branch:,help,model-deps:' -s sh -- "$@"`

--- a/src/5gmsaf/msaf-m5-sm.c
+++ b/src/5gmsaf/msaf-m5-sm.c
@@ -24,7 +24,6 @@
 #include "openapi/api/TS26512_M5_ConsumptionReportingAPI-info.h"
 #include "openapi/api/TS26512_M5_MetricsReportingAPI-info.h"
 #include "openapi/model/consumption_report.h"
-#include "string.h"
 
 const nf_server_interface_metadata_t
 m5_serviceaccessinformation_api_metadata = {

--- a/src/5gmsaf/msaf-m5-sm.c
+++ b/src/5gmsaf/msaf-m5-sm.c
@@ -22,7 +22,9 @@
 #include "data-collection.h"
 #include "openapi/api/TS26512_M5_ServiceAccessInformationAPI-info.h"
 #include "openapi/api/TS26512_M5_ConsumptionReportingAPI-info.h"
+#include "openapi/api/TS26512_M5_MetricsReportingAPI-info.h"
 #include "openapi/model/consumption_report.h"
+#include "string.h"
 
 const nf_server_interface_metadata_t
 m5_serviceaccessinformation_api_metadata = {
@@ -34,6 +36,12 @@ static const nf_server_interface_metadata_t
 m5_consumptionreporting_api_metadata = {
     M5_CONSUMPTIONREPORTING_API_NAME,
     M5_CONSUMPTIONREPORTING_API_VERSION
+};
+
+static const nf_server_interface_metadata_t
+m5_metricsreporting_api_metadata = {
+    M5_METRICSREPORTING_API_NAME,
+    M5_METRICSREPORTING_API_VERSION
 };
 
 void msaf_m5_state_initial(ogs_fsm_t *s, msaf_event_t *e)
@@ -64,6 +72,7 @@ void msaf_m5_state_functional(ogs_fsm_t *s, msaf_event_t *e)
     const nf_server_app_metadata_t app_metadata = { MSAF_NAME, MSAF_VERSION, nf_name};
     const nf_server_interface_metadata_t *m5_serviceaccessinformation_api = &m5_serviceaccessinformation_api_metadata;
     const nf_server_interface_metadata_t *m5_consumptionreporting_api = &m5_consumptionreporting_api_metadata;
+    const nf_server_interface_metadata_t *m5_metricsreporting_api = &m5_metricsreporting_api_metadata;
     const nf_server_app_metadata_t *app_meta = &app_metadata;
 
     ogs_assert(s);
@@ -239,7 +248,7 @@ void msaf_m5_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                         break;
                                     DEFAULT
                                         char *err;
-                                        err = ogs_msprintf("Unrecognised content type for Consumption Report for Provisioning Session [%s]", message->h.resource.component[1]);
+                                        err = ogs_msprintf("Unrecognised content type for Consumption Rfeport for Provisioning Session [%s]", message->h.resource.component[1]);
                                         ogs_error("%s", err);
                                         ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_UNSUPPORTED_MEDIA_TYPE, 1, message, "Malformed request body", err, NULL, m5_consumptionreporting_api, app_meta));
                                         ogs_free(err);
@@ -276,7 +285,94 @@ void msaf_m5_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                         ogs_free(err);
                     END
                     break;
-                DEFAULT
+
+                CASE("metrics-reporting")
+                    SWITCH(message->h.method)
+                    CASE(OGS_SBI_HTTP_METHOD_POST)
+                    if (message->h.resource.component[1] && message->h.resource.component[2] && !message->h.resource.component[3]) {
+                        msaf_provisioning_session_t *provisioning_session;
+                        provisioning_session = msaf_provisioning_session_find_by_provisioningSessionId(message->h.resource.component[1]);
+
+                        if (provisioning_session) {
+                            const char *content_type = "application/xml";  /* Client's metrics are in XML format */
+
+                            /* Find Content-Type header value */
+                            ogs_hash_index_t *hi;
+                            for (hi = ogs_hash_first(request->http.headers); hi; hi = ogs_hash_next(hi)) {
+                                if (!ogs_strcasecmp(ogs_hash_this_key(hi), OGS_SBI_CONTENT_TYPE)) {
+                                    content_type = ogs_hash_this_val(hi);
+                                    break;
+                                }
+                            }
+
+                            SWITCH(content_type)
+                            CASE("application/xml")
+
+                            /* Temporary auxiliary function to parse report time value directly from XML content */
+
+                            char* parseReportTime(const char* metricsXml) {
+                                const char *startTag = "reportTime=\"", *endTag = "\"";
+                                char *startPosition = strstr(metricsXml, startTag), *endPosition, *reportTime = NULL;
+
+                                if (startPosition && (endPosition = strstr(startPosition += strlen(startTag), endTag))) {
+                                    reportTime = strndup(startPosition, endPosition - startPosition);
+                                }
+                                return reportTime;
+                            }
+
+                            if (request->http.content) {
+
+                                char* reportTime = parseReportTime(request->http.content);
+
+                                if (msaf_data_collection_store(message->h.resource.component[1], "metrics_reports", message->h.resource.component[2], NULL, reportTime, "xml", request->http.content)) {
+                                    ogs_sbi_response_t *response;
+                                    response = nf_server_new_response(request->h.uri, NULL, 0, NULL, 0, NULL, m5_metricsreporting_api, app_meta);
+                                    ogs_assert(response);
+                                    nf_server_populate_response(response, 0, NULL, 204);
+                                    ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+                                } else {
+                                    char *err;
+                                    err = ogs_msprintf("Failed to store Metrics Report for provisioning session [%s]", message->h.resource.component[1]);
+                                    ogs_error("%s", err);
+                                    ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_INTERNAL_SERVER_ERROR, 1, message, "Data storage error", err, NULL, m5_metricsreporting_api, app_meta));
+                                    ogs_free(err);
+                                }
+                            } else {
+                                char *err;
+                                err = ogs_msprintf("No content in the HTTP request for the Metrics Report [%s]", message->h.resource.component[1]);
+                                ogs_error("%s", err);
+                                ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, 1, message, "No content in HTTP request.", err, NULL, m5_metricsreporting_api, app_meta));
+                                ogs_free(err);
+                            }
+                            break;
+                            DEFAULT
+                            char *err;
+                            err = ogs_msprintf("Unrecognised content type for Metrics Report for Provisioning Session [%s]", message->h.resource.component[1]);
+                            ogs_error("%s", err);
+                            ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_UNSUPPORTED_MEDIA_TYPE, 1, message, "Unsupported Media Type", err, NULL, m5_metricsreporting_api, app_meta));
+                            ogs_free(err);
+                            END
+                        } else {
+                            char *err;
+                            err = ogs_msprintf("Provisioning session [%s] not found for Metrics Report", message->h.resource.component[1]);
+                            ogs_error("%s", err);
+                            ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_NOT_FOUND, 1, message, "Not Found", err, NULL, m5_metricsreporting_api, app_meta));
+                            ogs_free(err);
+                        }
+                    } else {
+                        ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_NOT_FOUND, 0, message, "Not Found", NULL, NULL, m5_metricsreporting_api, app_meta));
+                    }
+                    break;
+                    DEFAULT
+                    char *err;
+                    err = ogs_msprintf("Method [%s] not implemented for M5 Metrics Reporting API", message->h.method);
+                    ogs_error("%s", err);
+                    ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_MEHTOD_NOT_ALLOWED, 1, message, "Method Not Allowed", err, NULL, m5_metricsreporting_api, app_meta));
+                    ogs_free(err);
+                    END
+                    break;
+
+            DEFAULT
                     ogs_error("Invalid resource name [%s]",
                             message->h.resource.component[0]);
                     ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, 1, message, "Invalid resource name.", message->h.resource.component[0], NULL, NULL, app_meta));


### PR DESCRIPTION
This PR adds Metrics Reporting API to the interface at the reference point M5.

It is an implementation of the `POST` method to retrieve XML metrics data from the client and utilizes `data-collection` functionalities in order to store metrics at a location specified by `msaf.dataCollectionDir` parameter of the related `.yaml` configuration file.
The successful `POST` operation results `204 No Content`.
It operates at:
`{apiRoot}/3gpp-m5/{apiVersion}/metrics-reporting/{provisioningSessionId}/{metricsReportingConfigurationId}` as defined at 11.4.2 of TS 26.512 (17.6.0)