### PR TITLE
Add PolicyTemplates to the msaf-configuration tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,7 @@ This project follows
 the [Gitflow workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow). The
 `development` branch of this project serves as an integration branch for new features. Consequently, please make sure to
 switch to the `development` branch before starting the implementation of a new feature.
+
+## Support
+
+The reference implementation of the Network Assistance and Dynamic Policies features was funded by the UK Government through the [REASON](https://reason-open-networks.ac.uk/) project.

--- a/src/5gmsaf/provisioning-session.c
+++ b/src/5gmsaf/provisioning-session.c
@@ -191,6 +191,15 @@ msaf_provisioning_session_get_json(const char *provisioning_session_id)
             OpenAPI_list_add(provisioning_session->server_certificate_ids, (void*)ogs_hash_this_key(cert_node));
         }
 
+        if (msaf_provisioning_session->policy_templates && ogs_hash_first(msaf_provisioning_session->policy_templates) != NULL) {
+            ogs_hash_index_t *pol_node;
+            provisioning_session->policy_template_ids = (OpenAPI_set_t*)OpenAPI_list_create();
+            for (pol_node=ogs_hash_first(msaf_provisioning_session->policy_templates); pol_node; pol_node=ogs_hash_next(pol_node)) {
+                ogs_debug("msaf_provisioning_session_get_json: Add policy template %s", (const char *)ogs_hash_this_key(pol_node));
+                OpenAPI_list_add(provisioning_session->policy_template_ids, (void*)ogs_hash_this_key(pol_node));
+            }
+        }
+
         provisioning_session_json = msaf_api_provisioning_session_convertResponseToJSON(provisioning_session);
 
         OpenAPI_list_free(provisioning_session->server_certificate_ids);

--- a/tools/python3/m1_session_cli.py
+++ b/tools/python3/m1_session_cli.py
@@ -150,7 +150,7 @@ if os.path.isdir(installed_packages_dir) and installed_packages_dir not in sys.p
 from rt_m1_client.session import M1Session
 from rt_m1_client.exceptions import M1Error
 from rt_m1_client.data_store import JSONFileDataStore
-from rt_m1_client.types import ContentHostingConfiguration, ConsumptionReportingConfiguration
+from rt_m1_client.types import ContentHostingConfiguration, ConsumptionReportingConfiguration, PolicyTemplate
 from rt_m1_client.configuration import Configuration
 
 async def cmd_configure_show(args: argparse.Namespace, config: Configuration) -> int:
@@ -277,6 +277,14 @@ async def cmd_list_verbose(args: argparse.Namespace, config: Configuration) -> i
             print(ConsumptionReportingConfiguration.format(crc, indent=4))
         else:
             print('    Not defined')
+        pol_ids = await session.policyTemplateIds(ps_id)
+        if pol_ids is not None and len(pol_ids) > 0:
+            print('  PolicyTemplates:')
+            for polid in pol_ids:
+                print(f'    {polid}:')
+                pol = await session.policyTemplateGet(ps_id, polid)
+                if pol is not None:
+                    print(PolicyTemplate.format(pol, indent=6))
     return 0
 
 async def cmd_list(args: argparse.Namespace, config: Configuration) -> int:

--- a/tools/python3/m1_sync_config.py
+++ b/tools/python3/m1_sync_config.py
@@ -97,6 +97,29 @@ This file defines the streams to configure and is located at
                 "samplePercentage": 66.666,
                 "locationReporting": true,
                 "accessReporting": true,
+            },
+            "policies": {
+                "policy-external-ref-1": {
+                    "applicationSessionContext": {
+                        "sliceInfo": {
+                            "sst": 1,
+                            "sd": "000001"
+                        },
+                        "dnn": "internet"
+                    },
+                    "qoSSpecification": {
+                        "qosReference": "qos-1",
+                        "maxAuthBtrUl": "200 Kbps",
+                        "maxAuthBtrDl": "20 Mbps",
+                        "defPacketLossRateDl": 0,
+                        "defPacketLossRateUl": 0
+                    },
+                    "chargingSpecification": {
+                        "sponId": "sponsor-id-1",
+                        "sponsorEnabled": true,
+                        "gpsi": ["msimsi-1234567890"]
+                    }
+                }
             }
         },
         "vod-root-1": {
@@ -109,6 +132,9 @@ This file defines the streams to configure and is located at
             "consumptionReporting": {
                 "reportingInterval": 20,
                 "samplePercentage": 80,
+            },
+            "policies": {
+                "policy-external-ref-1": {}
             }
         }
     },
@@ -186,7 +212,7 @@ if os.path.isdir(installed_packages_dir) and installed_packages_dir not in sys.p
 from rt_m1_client.session import M1Session
 from rt_m1_client.exceptions import M1Error
 from rt_m1_client.data_store import JSONFileDataStore
-from rt_m1_client.types import ContentHostingConfiguration, DistributionConfiguration, IngestConfiguration, M1MediaEntryPoint, PathRewriteRule, ConsumptionReportingConfiguration
+from rt_m1_client.types import ContentHostingConfiguration, DistributionConfiguration, IngestConfiguration, M1MediaEntryPoint, PathRewriteRule, ConsumptionReportingConfiguration, PolicyTemplate, M1QoSSpecification, ChargingSpecification, AppSessionContext, Snssai
 from rt_m1_client.configuration import Configuration
 
 g_streams_config = os.path.join(os.path.sep, 'etc', 'rt-5gms', 'streams.json')
@@ -293,21 +319,98 @@ async def consumption_reporting_equal(a: Optional[ConsumptionReportingConfigurat
         return False
     if b is None and a is not None:
         return False
-    if not await _flagsEqual(a.get('locationReporting'), b.get('locationReporting')):
+    for i in ['locationReporting', 'accessReporting']:
+        if not await _flagsEqual(a.get(i, None), b.get(i, None)):
+            return False
+    for i in ['reportingInterval', 'samplePercentage']:
+        if i in a and i not in b:
+            return False
+        if i in b and i not in a:
+            return False
+        if i in a and a[i] != b[i]:
+            return False
+    return True
+
+async def snssai_match(sai1: Optional[Snssai], sai2: Optional[Snssai]) -> bool:
+    if sai1 is None and sai2 is None:
+        return True
+    if sai1 is None or sai2 is None:
         return False
-    if not await _flagsEqual(a.get('accessReporting'), b.get('accessReporting')):
+    for i in ['sst', 'sd']:
+        if i not in sai1 and i in sai2:
+            return False
+        if i in sai1 and i not in sai2:
+            return False
+        if i in sai1 and sai1[i] != sai2[i]:
+            return False
+    return True
+
+async def m1_qos_specs_match(qos1: Optional[M1QoSSpecification], qos2: Optional[M1QoSSpecification]) -> bool:
+    if qos1 is None and qos2 is None:
+        return True
+    if qos1 is None or qos2 is None:
         return False
-    if 'reportingInterval' in a and 'reportingInterval' not in b:
+    for i in ['qosReference', 'maxAuthBtrUl', 'maxAuthBtrDl', 'defPacketLossRateDl', 'defPacketLossRateUl']:
+        if i not in qos1 and i in qos2:
+            return False
+        if i in qos1 and i not in qos2:
+            return False
+        if i in qos1 and qos1[i] != qos2[i]:
+            return False
+    return True
+
+async def policy_app_sessions_match(as1: Optional[AppSessionContext], as2: Optional[AppSessionContext]) -> bool:
+    if as1 is None and as2 is None:
+        return True
+    if as1 is None or as2 is None:
         return False
-    if 'reportingInterval' in b and 'reportingInterval' not in a:
+    if not await snssai_match(as1.get('sliceInfo', None), as2.get('sliceInfo', None)):
         return False
-    if 'reportingInterval' in a and a['reportingInterval'] != b['reportingInterval']:
+    if 'dnn' not in as1 and 'dnn' in as2:
         return False
-    if 'samplePercentage' in a and 'samplePercentage' not in b:
+    if 'dnn' in as1 and 'dnn' not in as2:
         return False
-    if 'samplePercentage' in b and 'samplePercentage' not in a:
+    if 'dnn' in as1 and as1['dnn'] != as2['dnn']:
         return False
-    if 'samplePercentage' in a and a['samplePercentage'] != b['samplePercentage']:
+    return True
+
+async def charging_specs_match(cs1: Optional[ChargingSpecification], cs2: Optional[ChargingSpecification]) -> bool:
+    if cs1 is None and cs2 is None:
+        return True
+    if cs1 is None or cs2 is None:
+        return False
+    for i in ['sponId', 'sponStatus']:
+        if i in cs1 and i not in cs2:
+            return False
+        if i not in cs1 and i in cs2:
+            return False
+        if i in cs1 and cs1[i] != cs2[i]:
+            return False
+    if 'gpsi' in cs1 and 'gpsi' not in cs2:
+        return False
+    if 'gpsi' not in cs1 and 'gpsi' in cs2:
+        return False
+    if 'gpsi' in cs1 and sorted(cs1['gpsi']) != sorted(cs2['gpsi']):
+        return False
+    return True
+
+async def policies_match(p1: Optional[PolicyTemplate], p2: Optional[PolicyTemplate]) -> bool:
+    if p1 is None and p2 is None:
+        return True
+    if p1 is None or p2 is None:
+        return False
+    if 'externalReference' in p1 and 'externalReference' not in p2:
+        return False
+    if 'externalReference' not in p1 and 'externalReference' in p2:
+        return False
+    if 'externalReference' in p1 and p1['externalReference'] != p2['externalReference']:
+        return False
+    if not await policy_app_sessions_match(p1.get('applicationSessionContext', None), p2.get('applicationSessionContext', None)):
+        return False
+    # ignore read-only fields policyTemplateId, state and stateReason
+    if not await m1_qos_specs_match(p1.get('qoSSpecification', None), p2.get('qoSSpecification', None)):
+        return False
+    if not await charging_specs_match(p1.get('chargingSpecification', None), p2.get('chargingSpecification', None)):
         return False
     return True
 
@@ -319,7 +422,7 @@ async def sync_configuration(m1: M1Session, streams: dict) -> dict:
     for ps_id in await m1.provisioningSessionIds():
         chc = await m1.contentHostingConfigurationGet(ps_id)
         if chc is None:
-            log_warn(f'Provisioning Session {ps_id} has no ContentHostingConfiguration')
+            log_warn(f'Provisioning Session {ps_id} has no ContentHostingConfiguration, removing from the AF')
             del_ps_id += [ps_id]
             continue
         for chk_id, chk_stream in to_check.items():
@@ -346,7 +449,8 @@ async def sync_configuration(m1: M1Session, streams: dict) -> dict:
                 },
                 'distributionConfigurations': cfg['distributionConfigurations'],
                 }
-        crc = cfg.get('consumptionReporting')
+        crc = cfg.get('consumptionReporting', None)
+        policies = cfg.get('policies', None)
         ps_id = await m1.createDownlinkPullProvisioningSession(streams.get('appId'), streams.get('aspId', None))
         if ps_id is None:
             log_error("Failed to create Provisioning Session for %r", cfg)
@@ -371,11 +475,29 @@ async def sync_configuration(m1: M1Session, streams: dict) -> dict:
             if crc is not None:
                 if not await m1.consumptionReportingConfigurationCreate(ps_id, crc):
                     log_error("Failed to activate ConsumptionReportingConfiguration for Provisioning Session %s")
-    # Check for ConsumptionReportingConfiguration changes in already configured sessions
+            if policies is not None:
+                if isinstance(policies,dict):
+                    pol_list = policies.items()
+                elif isinstance(policies,list):
+                    pol_list = [(p.get('externalReference', None), p) for p in policies]
+                else:
+                    log_error(f'Configured policies for provisioning session "{cfg_id}" should be an object or array')
+                    pol_list = None
+                if pol_list is not None:
+                    for ext_id, pol in pol_list:
+                        pt = dict()
+                        if ext_id is not None:
+                            pt.update({'externalReference': ext_id})
+                        pt.update(pol)
+                        result = await m1.policyTemplateCreate(ps_id, pt)
+                        if result is None:
+                            log_error(f'Failed to create policy template {ext_id!r} in provisioning session {ps_id}')
+    # Check for other changes in the configured sessions
     for cfg_id, cfg in have.items():
+        # Check for ConsumptionReportingConfiguration changes in already configured sessions
         ps_id = stream_map[cfg_id]
         old_crc: Optional[ConsumptionReportingConfiguration] = await m1.consumptionReportingConfigurationGet(ps_id)
-        new_crc: Optional[ConsumptionReportingConfiguration] = cfg.get('consumptionReporting')
+        new_crc: Optional[ConsumptionReportingConfiguration] = cfg.get('consumptionReporting', None)
         if not await consumption_reporting_equal(old_crc, new_crc):
             if old_crc is None:
                 # No pre-existing CRC, add the new one
@@ -389,6 +511,59 @@ async def sync_configuration(m1: M1Session, streams: dict) -> dict:
                 # The CRC has changed, update it
                 if not await m1.consumptionReportingConfigurationUpdate(ps_id, new_crc):
                     log_error("Failed to update ConsumptionReportingConfiguration for Provisioning Session %s", ps_id)
+        # Check PolicyTemplates for changes in the already configured sessions
+        del_policy: List[ResourceId] = []
+        have_policy: List[ResourceId] = []
+        new_policy: List[PolicyTemplate] = []
+        old_pol_ids: Optional[List[ResourceId]] = await m1.policyTemplateIds(ps_id)
+        policies = cfg.get('policies', None)
+        pol_list = None
+        if policies is not None:
+            if isinstance(policies,dict):
+                pol_list = policies.items()
+            elif isinstance(policies,list):
+                pol_list = [(p.get('externalReference', None), p) for p in policies]
+            else:
+                log_error(f'Configured policies for provisioning session "{cfg_id}" should be an object or array')
+        if old_pol_ids is None or len(old_pol_ids) == 0:
+            if policies is not None:
+                if pol_list is not None:
+                    for pol_ext_id, pol in pol_list:
+                        pt = dict()
+                        if pol_ext_id is not None:
+                            pt.update({'externalReference': pol_ext_id})
+                        pt.update(pol)
+                        new_policy += [pt]
+        else:
+            new_pol_left = pol_list
+            for pol_id in old_pol_ids:
+                if new_pol_left is None or len(new_pol_left) == 0:
+                    del_policy += [pol_id]
+                else:
+                    old_pol: Optional[PolicyTemplate] = await m1.policyTemplateGet(ps_id, pol_id)
+                    next_new_pol_list = []
+                    found = False
+                    for pol_ext_id, pol in new_pol_left:
+                        if not found and await policies_match(old_pol, pol):
+                            have_policy += [pol_id]
+                            found = True
+                        else:
+                            next_new_pol_list += [(pol_ext_id, pol)]
+                    if not found:
+                        del_policy += [pol_id]
+                    new_pol_left = next_new_pol_list
+            for pol_ext_id, pol in new_pol_left:
+                pt = dict()
+                if pol_ext_id is not None:
+                    pt.update({'externalReference': pol_ext_id})
+                pt.update(pol)
+                new_policy += [pt]
+        # Now we have del_policy as a list of policy ids to delete, have_policy as a list of ids to keep and new_policy as a list
+        # of new policies to add.
+        for pol_id in del_policy:
+            await m1.policyTemplateDelete(ps_id, pol_id)
+        for pol in new_policy:
+            await m1.policyTemplateCreate(ps_id, pol)
     return stream_map
 
 async def get_app_config() -> configparser.ConfigParser:


### PR DESCRIPTION
This PR adds the ability for the `msaf-configuration` tool to pick up a `streams.policies` section of the _streams.json_ file.
The data in this section is used to synchronise PolicyTemplates for the provisioning session by utilising the M1 reference point of the 5GMS AF.

This also adds the output of policy template ids for the provisioning session in the ProvisioningSession object and fixes some caching issues for Policy Templates in the M1Session python class.

The final part is documentation to note that the REASON project funded some of the development of the Network Assistance and Dynamic Policies features.