### PR TITLE
Add cmake and pyOpenSSL as dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ A list of currently supported features is available [here](https://github.com/5G
 ## Install dependencies
 
 ```bash
-sudo apt install git python3-pip python3-venv python3-setuptools python3-wheel ninja-build build-essential flex bison git libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev meson curl wget default-jdk
-python3 -m pip install build
+sudo apt install git python3-pip python3-venv python3-setuptools python3-wheel ninja-build build-essential flex bison git libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev meson curl wget default-jdk cmake
+python3 -m pip install build pyOpenSSL
 ```
 
 ## Downloading


### PR DESCRIPTION
When doing a clean installation on an Ubuntu22 machine I ran into two minor issues with cmake and OpenSSL not being found. Adding them to the list of dependencies in the Readme.