### PR TITLE
Enhancement: Uplift to TS26.512 v17.7.0

### DIFF
--- a/examples/ConsumptionReportingConfiguration.json
+++ b/examples/ConsumptionReportingConfiguration.json
@@ -1,0 +1,6 @@
+{
+	"reportingInterval":	10,
+	"locationReporting":	false,
+	"accessReporting":	false,
+	"samplePercentage":	90
+}

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,3 @@
 option('latest_apis', type: 'boolean', value: false)
-option('fiveg_api_approval', type: 'string', value: '101')
+option('fiveg_api_approval', type: 'string', value: '102')
 option('fiveg_api_release', type: 'string', value: '17')

--- a/src/5gmsaf/consumption-report-configuration.c
+++ b/src/5gmsaf/consumption-report-configuration.c
@@ -102,20 +102,6 @@ msaf_api_consumption_reporting_configuration_t *msaf_consumption_report_configur
         return NULL;
     }
 
-#if 0
-    if (crc->is_sample_percentage && (crc->sample_percentage < 0.0 || crc->sample_percentage > 100.0)) {
-        *err_out = "Bad value: samplePercentage out of range, should be between 0.0 and 100.0 inclusive";
-        msaf_api_consumption_reporting_configuration_free(crc);
-        return NULL;
-    }
-
-    if (crc->is_reporting_interval && crc->reporting_interval <= 0) {
-        *err_out = "Bad value: reportingInterval must be greater than 0";
-        msaf_api_consumption_reporting_configuration_free(crc);
-        return NULL;
-    }
-#endif
-
     return crc;
 }
 

--- a/src/5gmsaf/policy-template.c
+++ b/src/5gmsaf/policy-template.c
@@ -13,12 +13,6 @@ https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 #include "hash.h"
 #include "sai-cache.h"
 
-#if 0
-static msaf_api_m1_qo_s_specification_t *msaf_policy_template_qos_specification_new(cJSON *policy_template);
-static msaf_api_policy_template_application_session_context_t *msaf_policy_template_application_session_context(cJSON *policy_template);
-static msaf_api_charging_specification_t *msaf_policy_template_charging_specification(cJSON *policy_template);
-#endif
-
 static void msaf_policy_template_set_state_reason(msaf_api_policy_template_t *policy_template, char *cause, char *detail, char *instance, char *nrf_id, char *supported_features, char *title, char *type);
 
 /***** Public functions *****/
@@ -200,18 +194,6 @@ bool msaf_policy_template_set_state(msaf_api_policy_template_t *policy_template,
    }
    return false;
 
-}
-
-msaf_api_policy_template_t *msaf_policy_template_new(const char *external_reference, msaf_api_m1_qo_s_specification_t *qos_specification, msaf_api_policy_template_application_session_context_t *application_session_context, msaf_api_charging_specification_t *charging_specification)
-{
-    msaf_api_policy_template_t *policy_template;
-    char *policy_template_id = NULL;
-    msaf_api_policy_template_state_e state = msaf_api_policy_template_STATE_NULL;
-
-    policy_template = msaf_api_policy_template_create(application_session_context, charging_specification,
-                    msaf_strdup(external_reference), policy_template_id, qos_specification, state, NULL);
-
-    return policy_template;
 }
 
 cJSON *msaf_policy_template_convertToJSON(msaf_api_policy_template_t *policy_template)

--- a/src/5gmsaf/policy-template.h
+++ b/src/5gmsaf/policy-template.h
@@ -21,8 +21,6 @@ extern "C" {
 
 #define msaf_policy_template_free(policy_template) msaf_api_policy_template_free(policy_template)
 
-extern msaf_api_policy_template_t *msaf_policy_template_new(const char *external_reference, msaf_api_m1_qo_s_specification_t *qos_specification, msaf_api_policy_template_application_session_context_t *application_session_context, msaf_api_charging_specification_t *charging_specification);
-
 extern bool msaf_policy_template_set_state(msaf_api_policy_template_t *policy_template, msaf_api_policy_template_state_e new_state, msaf_provisioning_session_t *provisioning_session);
 
 extern void msaf_policy_template_set_id(msaf_api_policy_template_t *policy_template, const char *policy_template_id);

--- a/src/5gmsaf/provisioning-session.h
+++ b/src/5gmsaf/provisioning-session.h
@@ -40,7 +40,7 @@ typedef struct msaf_provisioning_session_s {
     char *provisioningSessionId;
     msaf_api_provisioning_session_type_e provisioningSessionType;
     char *aspId;
-    char *externalApplicationId;
+    char *appId;
     msaf_api_consumption_reporting_configuration_t *consumptionReportingConfiguration;
     msaf_api_content_hosting_configuration_t *contentHostingConfiguration;
     msaf_sai_cache_t *sai_cache;
@@ -97,7 +97,7 @@ extern void msaf_provisioning_session_certificate_hash_remove(const char *provis
 
 extern int uri_relative_check(const char *entry_point_path);
 
-extern int msaf_distribution_create(cJSON *content_hosting_config, msaf_provisioning_session_t *provisioning_session);
+extern int msaf_distribution_create(cJSON *content_hosting_config, msaf_provisioning_session_t *provisioning_session, const char **reason_ret);
 
 extern cJSON *msaf_get_content_hosting_configuration_by_provisioning_session_id(const char *provisioning_session_id);
 

--- a/src/5gmsaf/service-access-information.c
+++ b/src/5gmsaf/service-access-information.c
@@ -28,6 +28,8 @@ https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 
 #include "service-access-information.h"
 
+static OpenAPI_list_t *_policy_templates_hash_to_list_of_ready_bindings(ogs_hash_t *policy_templates);
+
 msaf_api_service_access_information_resource_t *
 msaf_context_service_access_information_create(msaf_provisioning_session_t *provisioning_session, bool is_tls, const char *svr_hostname)
 {
@@ -45,41 +47,40 @@ msaf_context_service_access_information_create(msaf_provisioning_session_t *prov
         OpenAPI_lnode_t *node;
         OpenAPI_list_for_each(provisioning_session->contentHostingConfiguration->distribution_configurations, node) {
             msaf_api_distribution_configuration_t *dist_conf = node->data;
-	    if (dist_conf->entry_point && dist_conf->base_url) {
-		msaf_api_m5_media_entry_point_t *m5_entry;
-	        char *url;
+            if (dist_conf->entry_point && dist_conf->base_url) {
+                msaf_api_m5_media_entry_point_t *m5_entry;
+                char *url;
                 OpenAPI_list_t *m5_profiles = NULL;
 
-		if (dist_conf->entry_point->profiles) {
-		    OpenAPI_lnode_t *prof_node;
-		    m5_profiles = OpenAPI_list_create();
-		    OpenAPI_list_for_each(dist_conf->entry_point->profiles, prof_node) {
-			OpenAPI_list_add(m5_profiles, ogs_strdup(prof_node->data));
-		    }
-		}
+                if (dist_conf->entry_point->profiles) {
+                    OpenAPI_lnode_t *prof_node;
+                    m5_profiles = OpenAPI_list_create();
+                    OpenAPI_list_for_each(dist_conf->entry_point->profiles, prof_node) {
+                        OpenAPI_list_add(m5_profiles, ogs_strdup(prof_node->data));
+                    }
+                }
 
-		url = ogs_msprintf("%s%s", dist_conf->base_url, dist_conf->entry_point->relative_path);
-		m5_entry = msaf_api_m5_media_entry_point_create(url, ogs_strdup(dist_conf->entry_point->content_type), m5_profiles);
-		ogs_assert(m5_entry);
-		if (!entry_points) entry_points = OpenAPI_list_create();
-		OpenAPI_list_add(entry_points, m5_entry);
-	    }
-	}
+                url = ogs_msprintf("%s%s", dist_conf->base_url, dist_conf->entry_point->relative_path);
+                m5_entry = msaf_api_m5_media_entry_point_create(url, ogs_strdup(dist_conf->entry_point->content_type), m5_profiles);
+                ogs_assert(m5_entry);
+                if (!entry_points) entry_points = OpenAPI_list_create();
+                OpenAPI_list_add(entry_points, m5_entry);
+            }
+        }
     }
     streaming_access = msaf_api_service_access_information_resource_streaming_access_create(entry_points, NULL);
 
     // Dynamic policy invocation configuration
     if (provisioning_session->policy_templates) {
         OpenAPI_list_t *policy_templates_svr_list;
-        OpenAPI_list_t *valid_policy_template_ids;
-        OpenAPI_list_t *external_references;
-	msaf_api_sdf_method_e sdf_method = msaf_api_sdf_method__5_TUPLE;
+        OpenAPI_list_t *policy_template_bindings;
+        msaf_api_sdf_method_e sdf_method = msaf_api_sdf_method__5_TUPLE;
         OpenAPI_list_t *sdf_methods;
 
-	valid_policy_template_ids = msaf_provisioning_session_get_id_of_policy_templates_in_ready_state(provisioning_session);
+        policy_template_bindings = _policy_templates_hash_to_list_of_ready_bindings(provisioning_session->policy_templates);
 
-        if (valid_policy_template_ids) {
-            if (valid_policy_template_ids->first != NULL) {
+        if (policy_template_bindings) {
+            if (policy_template_bindings->first != NULL) {
                 ogs_debug("Adding dynamicPolicyInvocationConfiguration to ServiceAccessInformation [%s]",
                            provisioning_session->provisioningSessionId);
 
@@ -91,13 +92,10 @@ msaf_context_service_access_information_create(msaf_provisioning_session_t *prov
                 ogs_assert(sdf_methods);
                 OpenAPI_list_add(sdf_methods, (void *)sdf_method);
         
-                external_references = msaf_provisioning_session_get_external_reference_of_policy_templates_in_ready_state(
-                        provisioning_session);
-        
                 dpic = msaf_api_service_access_information_resource_dynamic_policy_invocation_configuration_create(
-                            policy_templates_svr_list, valid_policy_template_ids, sdf_methods, external_references);
+                            policy_templates_svr_list, policy_template_bindings, sdf_methods);
             } else {
-                OpenAPI_list_free(valid_policy_template_ids);
+                OpenAPI_list_free(policy_template_bindings);
             }
         }
     }
@@ -111,16 +109,15 @@ msaf_context_service_access_information_create(msaf_provisioning_session_t *prov
                   provisioning_session->provisioningSessionId);
 
         ccrc_svr_list = OpenAPI_list_create();
-	ogs_assert(ccrc_svr_list);
+        ogs_assert(ccrc_svr_list);
         OpenAPI_list_add(ccrc_svr_list, ogs_msprintf("http%s://%s/3gpp-m5/v2/", is_tls?"s":"", svr_hostname));
         ccrc = msaf_api_service_access_information_resource_client_consumption_reporting_configuration_create(
-                    provisioning_session->consumptionReportingConfiguration->is_reporting_interval,
-                    provisioning_session->consumptionReportingConfiguration->reporting_interval,
+                    provisioning_session->consumptionReportingConfiguration->reporting_interval?true:false,
+                    *provisioning_session->consumptionReportingConfiguration->reporting_interval,
                     ccrc_svr_list,
                     provisioning_session->consumptionReportingConfiguration->is_location_reporting?
                         provisioning_session->consumptionReportingConfiguration->location_reporting:
                         0,
-                    true, /* TS 26.512 Table 11.2.3.1-1 says the accessReporting field is mandatory */
                     provisioning_session->consumptionReportingConfiguration->is_access_reporting?
                         provisioning_session->consumptionReportingConfiguration->access_reporting:
                         0,
@@ -133,13 +130,13 @@ msaf_context_service_access_information_create(msaf_provisioning_session_t *prov
 
     /* Network Assistance Configuration */
     if (config->offerNetworkAssistance) {
-	OpenAPI_list_t *na_svr_list;
+        OpenAPI_list_t *na_svr_list;
 
-	na_svr_list = OpenAPI_list_create();
-	ogs_assert(na_svr_list);
-	OpenAPI_list_add(na_svr_list, ogs_msprintf("http%s://%s/3gpp-m5/v2/", is_tls?"s":"", svr_hostname));
-	nac = msaf_api_service_access_information_resource_network_assistance_configuration_create(na_svr_list);
-	ogs_assert(nac);
+        na_svr_list = OpenAPI_list_create();
+        ogs_assert(na_svr_list);
+        OpenAPI_list_add(na_svr_list, ogs_msprintf("http%s://%s/3gpp-m5/v2/", is_tls?"s":"", svr_hostname));
+        nac = msaf_api_service_access_information_resource_network_assistance_configuration_create(na_svr_list);
+        ogs_assert(nac);
     }
 
     /* Create SAI */
@@ -176,14 +173,14 @@ const msaf_sai_cache_entry_t *msaf_context_retrieve_service_access_information(c
     }
 
     if (!sai_entry) {
-	msaf_api_service_access_information_resource_t *sai;
+        msaf_api_service_access_information_resource_t *sai;
 
         ogs_debug("Create new SAI for http%s://%s on provisioning session [%s]", is_tls?"s":"", authority, provisioning_session_id);
 
-	sai = msaf_context_service_access_information_create(provisioning_session_context, is_tls, authority);
-	msaf_sai_cache_add(provisioning_session_context->sai_cache, is_tls, authority, sai);
-	msaf_api_service_access_information_resource_free(sai);
-	sai_entry = msaf_sai_cache_find(provisioning_session_context->sai_cache, is_tls, authority);
+        sai = msaf_context_service_access_information_create(provisioning_session_context, is_tls, authority);
+        msaf_sai_cache_add(provisioning_session_context->sai_cache, is_tls, authority, sai);
+        msaf_api_service_access_information_resource_free(sai);
+        sai_entry = msaf_sai_cache_find(provisioning_session_context->sai_cache, is_tls, authority);
     } else {
         ogs_debug("Found existing SAI cache entry");
     }
@@ -194,6 +191,27 @@ const msaf_sai_cache_entry_t *msaf_context_retrieve_service_access_information(c
 
     return sai_entry;
 }
+
+static OpenAPI_list_t *_policy_templates_hash_to_list_of_ready_bindings(ogs_hash_t *policy_templates)
+{
+    msaf_policy_template_node_t *policy_template_node;
+    OpenAPI_list_t *policy_template_bindings;
+    ogs_hash_index_t *hi;
+    msaf_api_service_access_information_resource_dynamic_policy_invocation_configuration_policy_template_bindings_inner_t *policy_template_binding;
+
+    policy_template_bindings = OpenAPI_list_create();
+
+    for (hi = ogs_hash_first(policy_templates);
+            hi; hi = ogs_hash_next(hi)) {
+        policy_template_node = (msaf_policy_template_node_t *)ogs_hash_this_val(hi);
+        if (policy_template_node->policy_template->state == msaf_api_policy_template_STATE_READY) {
+            policy_template_binding = msaf_api_service_access_information_resource_dynamic_policy_invocation_configuration_policy_template_bindings_inner_create(msaf_strdup(policy_template_node->policy_template->external_reference), msaf_strdup(policy_template_node->policy_template->policy_template_id));
+            OpenAPI_list_add(policy_template_bindings, policy_template_binding);
+        }
+    }
+    return policy_template_bindings;
+}
+
 
 /* vim:ts=8:sts=4:sw=4:expandtab:
  */

--- a/tools/python3/lib/rt_m1_client/client.py
+++ b/tools/python3/lib/rt_m1_client/client.py
@@ -133,7 +133,7 @@ class M1Client:
                      provisioning_session_type, external_application_id, asp_id)
         send: ProvisioningSession = {
                 'provisioningSessionType': provisioning_session_type,
-                'externalApplicationId': external_application_id
+                'appId': external_application_id
                 }
         if asp_id is not None:
             send['aspId'] = asp_id

--- a/tools/python3/lib/rt_m1_client/types.py
+++ b/tools/python3/lib/rt_m1_client/types.py
@@ -46,11 +46,11 @@ ProvisioningSessionId = ResourceId
 ProvisioningSessionType = Literal['DOWNLINK','UPLINK']
 
 class ProvisioningSessionMandatory(TypedDict):
-    '''Madatory fields for a `ProvisioningSession`
+    '''Madatory fields for a `ProvisioningSession` v17.7.0
     '''
     provisioningSessionId: ProvisioningSessionId
     provisioningSessionType: ProvisioningSessionType
-    externalApplicationId: ApplicationId
+    appId: ApplicationId
 
 class ProvisioningSession (ProvisioningSessionMandatory, total=False):
     '''A `ProvisioningSession` object as defined in TS 26.512
@@ -779,13 +779,13 @@ class PolicyTemplateMandatory(TypedDict):
     Mandatory fields from PolicyTemplate structure in TS 26.512
     '''
     externalReference: str
-    applicationSessionContext: AppSessionContext
 
 class PolicyTemplate(PolicyTemplateMandatory, total=False):
     '''
     PolicyTemplate structure from TS 26.512
     '''
     policyTemplateId: ResourceId
+    applicationSessionContext: AppSessionContext
     state: PolicyTemplateState
     stateReason: "ProblemDetail"
     qoSSpecification: M1QoSSpecification
@@ -817,7 +817,8 @@ class PolicyTemplate(PolicyTemplateMandatory, total=False):
         if 'state' in pt:
             pt['state'] = PolicyTemplateState[pt['state']]
         #ProblemDetail.validate(pt['stateReason'])
-        AppSessionContext.validate(pt['applicationSessionContext'], policy_template_json)
+        if 'applicationSessionContext' in pt:
+            AppSessionContext.validate(pt['applicationSessionContext'], policy_template_json)
         if 'qoSSpecification' in pt:
             M1QoSSpecification.validate(pt['qoSSpecification'], policy_template_json)
         if 'chargingSpecification' in pt:
@@ -833,9 +834,9 @@ class PolicyTemplate(PolicyTemplateMandatory, total=False):
 {prefix}  State Reason:
 {ProblemDetail.format(pt['stateReason'],indent+4)}
 {prefix}  External Reference: {pt['externalReference']}
-{prefix}  AppSessionContext:
-{AppSessionContext.format(pt['applicationSessionContext'], indent+4)}
 '''
+        if 'applicationSessionContext' in pt:
+            ret += f"{prefix}  AppSessionContext:\n{AppSessionContext.format(pt['applicationSessionContext'], indent+4)}"
         if 'qoSSpecification' in pt:
             ret += f"{prefix}  QoS Specification:\n{M1QoSSpecification.format(pt['qoSSpecification'], indent+4)}"
         if 'chargingSpecification' in pt:

--- a/tools/python3/lib/rt_m1_client/types.py
+++ b/tools/python3/lib/rt_m1_client/types.py
@@ -46,7 +46,7 @@ ProvisioningSessionId = ResourceId
 ProvisioningSessionType = Literal['DOWNLINK','UPLINK']
 
 class ProvisioningSessionMandatory(TypedDict):
-    '''Madatory fields for a `ProvisioningSession` v17.7.0
+    '''Mandatory fields for a `ProvisioningSession` v17.7.0
     '''
     provisioningSessionId: ProvisioningSessionId
     provisioningSessionType: ProvisioningSessionType


### PR DESCRIPTION
This updates the code in line with changes agreed for 3GPP TS 26.512 v17.7.0.

Closes #112 
Closes #113
Closes #115 

Please see #112 and #113 for full details of the v17.7.0 changes, and #115 for the changes needed to accommodate the clarification of consumption reporting in v17.7.0.