### PR TITLE
Bug fix: Policy templates field validation

### DIFF
--- a/examples/PolicyTemplate-1.json
+++ b/examples/PolicyTemplate-1.json
@@ -9,8 +9,6 @@
   },
   "qoSSpecification": {
     "qosReference": "qos-1",
-    "maxBtrUl": "100 Kbps",
-    "maxBtrDl": "10 Mbps",
     "maxAuthBtrUl": "200 Kbps",
     "maxAuthBtrDl": "20 Mbps",
     "defPacketLossRateDl": 0,
@@ -19,6 +17,6 @@
   "chargingSpecification": {
     "sponId": "sponsor-id-1",
     "sponStatus": "SPONSOR_ENABLED",
-    "gpsi": ["msimsi-1234567890"]
+    "gpsi": ["msisdn-441234567890"]
   }
 }

--- a/examples/PolicyTemplate-1b.json
+++ b/examples/PolicyTemplate-1b.json
@@ -9,8 +9,6 @@
   },
   "qoSSpecification": {
     "qosReference": "qos-1",
-    "maxBtrUl": "200 Kbps",
-    "maxBtrDl": "20 Mbps",
     "maxAuthBtrUl": "400 Kbps",
     "maxAuthBtrDl": "40 Mbps",
     "defPacketLossRateDl": 10,
@@ -19,6 +17,6 @@
   "chargingSpecification": {
     "sponId": "sponsor-id-2",
     "sponStatus": "SPONSOR_ENABLED",
-    "gpsi": ["msimsi-447000123456"]
+    "gpsi": ["msisdn-447000123456"]
   }
 }

--- a/examples/PolicyTemplate-2.json
+++ b/examples/PolicyTemplate-2.json
@@ -9,8 +9,6 @@
   },
   "qoSSpecification": {
     "qosReference": "qos-2",
-    "maxBtrUl": "150 Kbps",
-    "maxBtrDl": "15 Mbps",
     "maxAuthBtrUl": "300 Kbps",
     "maxAuthBtrDl": "30 Mbps",
     "defPacketLossRateDl": 5,
@@ -19,6 +17,6 @@
   "chargingSpecification": {
     "sponId": "sponsor-id-3",
     "sponStatus": "SPONSOR_ENABLED",
-    "gpsi": ["msimsi-447000654321"]
+    "gpsi": ["msisdn-447000654321"]
   }
 }

--- a/src/5gmsaf/openapi-templates/model-body.mustache
+++ b/src/5gmsaf/openapi-templates/model-body.mustache
@@ -778,28 +778,28 @@ cJSON *{{classname}}_convertResponseToJSON(const {{classname}}_t *{{classname}})
     }
     *{{name}}Ptr = {{{name}}}->valuedouble;
 		    {{#composedSchemas.allOf.0.minimum}}
-    if ({{{name}}}->valuedouble <{{#composedSchemas.allOf.0.exclusiveMinimum}}={{/composedSchemas.allOf.0.exclusiveMinimum}} {{composedSchemas.allOf.0.minimum}}) {
+    if (*{{name}}Ptr <{{#composedSchemas.allOf.0.exclusiveMinimum}}={{/composedSchemas.allOf.0.exclusiveMinimum}} {{composedSchemas.allOf.0.minimum}}) {
         ogs_error("{{classname}}_parseFromJSON() failed [{{{name}}}]: Out of range, number less than {{#composedSchemas.allOf.0.exclusiveMinimum}}or equal to {{/composedSchemas.allOf.0.exclusiveMinimum}}{{composedSchemas.allOf.0.minimum}}");
         if ({{classname}}_parse_err) *{{classname}}_parse_err = "Field \"{{{baseName}}}\" value is less than {{#composedSchemas.allOf.0.exclusiveMinimum}}or equal to {{/composedSchemas.allOf.0.exclusiveMinimum}}{{composedSchemas.allOf.0.minimum}} [range {{#composedSchemas.allOf.0.exclusiveMinimum}}({{/composedSchemas.allOf.0.exclusiveMinimum}}{{^composedSchemas.allOf.0.exclusiveMinimum}}[{{/composedSchemas.allOf.0.exclusiveMinimum}}{{composedSchemas.allOf.0.minimum}}..{{#composedSchemas.allOf.0.maximum}}{{composedSchemas.allOf.0.maximum}}{{#composedSchemas.allOf.0.exclusiveMaximum}}){{/composedSchemas.allOf.0.exclusiveMaximum}}{{^composedSchemas.allOf.0.exclusiveMaximum}}]{{/composedSchemas.allOf.0.exclusiveMaximum}}{{/composedSchemas.allOf.0.maximum}}{{^composedSchemas.allOf.0.maximum}}inf]{{/composedSchemas.allOf.0.maximum}}]";
         goto end;
     }
                     {{/composedSchemas.allOf.0.minimum}}
                     {{#minimum}}
-    if ({{{name}}}->valuedouble <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}}) {
+    if (*{{name}}Ptr <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}}) {
         ogs_error("{{classname}}_parseFromJSON() failed [{{{name}}}]: Out of range, number less than {{#exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}}");
         if ({{classname}}_parse_err) *{{classname}}_parse_err = "Field \"{{{baseName}}}\" value is less than {{#exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}} [range {{#exclusiveMinimum}}({{/exclusiveMinimum}}{{^exclusiveMinimum}}[{{/exclusiveMinimum}}{{minimum}}..{{#maximum}}{{maximum}}{{#exclusiveMaximum}}){{/exclusiveMaximum}}{{^exclusiveMaximum}}]{{/exclusiveMaximum}}{{/maximum}}{{^maximum}}inf]{{/maximum}}]";
         goto end;
     }
                     {{/minimum}}
 		    {{#composedSchemas.allOf.0.maximum}}
-    if ({{{name}}}->valuedouble >{{#composedSchemas.allOf.0.exclusiveMaximum}}={{/composedSchemas.allOf.0.exclusiveMaximum}} {{composedSchemas.allOf.0.maximum}}) {
+    if (*{{name}}Ptr >{{#composedSchemas.allOf.0.exclusiveMaximum}}={{/composedSchemas.allOf.0.exclusiveMaximum}} {{composedSchemas.allOf.0.maximum}}) {
         ogs_error("{{classname}}_parseFromJSON() failed [{{{name}}}]: Out of range, number greater than {{#composedSchemas.allOf.0.exclusiveMaximum}}or equal to {{/composedSchemas.allOf.0.exclusiveMaximum}}{{composedSchemas.allOf.0.maximum}}");
         if ({{classname}}_parse_err) *{{classname}}_parse_err = "Field \"{{{baseName}}}\" value is greater than {{#composedSchemas.allOf.0.exclusiveMaximum}}or equal to {{/composedSchemas.allOf.0.exclusiveMaximum}}{{composedSchemas.allOf.0.maximum}} [range {{#composedSchemas.allOf.0.minimum}}{{#composedSchemas.allOf.0.exclusiveMinimum}}({{/composedSchemas.allOf.0.exclusiveMinimum}}{{^composedSchemas.allOf.0.exclusiveMinimum}}[{{/composedSchemas.allOf.0.exclusiveMinimum}}{{composedSchemas.allOf.0.minimum}}{{/composedSchemas.allOf.0.minimum}}{{^composedSchemas.allOf.0.minimum}}[-inf{{/composedSchemas.allOf.0.minimum}}..{{composedSchemas.allOf.0.maximum}}{{#composedSchemas.allOf.0.exclusiveMaximum}}){{/composedSchemas.allOf.0.exclusiveMaximum}}{{^composedSchemas.allOf.0.exclusiveMaximum}}]{{/composedSchemas.allOf.0.exclusiveMaximum}}]";
         goto end;
     }
                     {{/composedSchemas.allOf.0.maximum}}
                     {{#maximum}}
-    if ({{{name}}}->valuedouble >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}}) {
+    if (*{{name}}Ptr >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}}) {
         ogs_error("{{classname}}_parseFromJSON() failed [{{{name}}}]: Out of range, number greater than {{#exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}");
         if ({{classname}}_parse_err) *{{classname}}_parse_err = "Field \"{{{baseName}}}\" value is greater than {{#exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}} [range {{#minimum}}{{#exclusiveMinimum}}({{/exclusiveMinimum}}{{^exclusiveMinimum}}[{{/exclusiveMinimum}}{{minimum}}{{/minimum}}{{^minimum}}[-inf{{/minimum}}..{{maximum}}{{#exclusiveMaximum}}){{/exclusiveMaximum}}{{^exclusiveMaximum}}]{{/exclusiveMaximum}}]";
         goto end;
@@ -842,14 +842,14 @@ cJSON *{{classname}}_convertResponseToJSON(const {{classname}}_t *{{classname}})
         goto end;
     }
 		  {{#minimum}}
-    if ({{{name}}}->valuedouble <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}}) {
+    if (({{dataType}})({{{name}}}->valuedouble) <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}}) {
         ogs_error("{{classname}}_parseFromJSON() failed [{{{name}}}]: Out of range, number less than {{#exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}}");
 	if ({{classname}}_parse_err) *{{classname}}_parse_err = "Field \"{{{baseName}}}\" value is less than {{#exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}} [range {{#exclusiveMinimum}}({{/exclusiveMinimum}}{{^exclusiveMinimum}}[{{/exclusiveMinimum}}{{minimum}}..{{#maximum}}{{maximum}}{{#exclusiveMaximum}}){{/exclusiveMaximum}}{{^exclusiveMaximum}}]{{/exclusiveMaximum}}{{/maximum}}{{^maximum}}inf]{{/maximum}}]";
         goto end;
     }
                   {{/minimum}}
                   {{#maximum}}
-    if ({{{name}}}->valuedouble >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}}) {
+    if (({{dataType}})({{{name}}}->valuedouble) >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}}) {
         ogs_error("{{classname}}_parseFromJSON() failed [{{{name}}}]: Out of range, number greater than {{#exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}");
 	if ({{classname}}_parse_err) *{{classname}}_parse_err = "Field \"{{{baseName}}}\" value is greater than {{#exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}} [range {{#minimum}}{{#exclusiveMinimum}}({{/exclusiveMinimum}}{{^exclusiveMinimum}}[{{/exclusiveMinimum}}{{minimum}}{{/minimum}}{{^minimum}}[-inf{{/minimum}}..{{maximum}}{{#exclusiveMaximum}}){{/exclusiveMaximum}}{{^exclusiveMaximum}}]{{/exclusiveMaximum}}]";
         goto end;

--- a/src/5gmsaf/utilities.c
+++ b/src/5gmsaf/utilities.c
@@ -20,6 +20,7 @@ https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
 #include <ctype.h>
 #include <ctype.h>
 #include <time.h>
+#include <math.h>
 
 #include "utilities.h"
 
@@ -137,6 +138,66 @@ uint16_t ascii_to_uint16(const char *str)
         ret = 0;
     }
     return ret;
+}
+
+/** TS 29.571 BitRate String to bit rate
+ * This converts a TS 29.571 BitRate string into a double representing the bit rate.
+ *
+ * @param ts29571_bitrate [in] The TS 29.571 BitRate string.
+ * @param err [out,null] A pointer to set for the reason for a parse error.
+ *
+ * @return The bit rate parsed from the string or @const NAN if there was a parse error (*err will point to the error string if err
+ *         is not @const NULL).
+ */
+double str_to_bitrate(const char *ts29571_bitrate, const char **err)
+{
+    double bitrate = NAN;
+    const char *units;
+    char *end = NULL;
+
+    if (!ts29571_bitrate) {
+        if (err) *err = "No bitrate to convert";
+        return bitrate;
+    }
+    units = strrchr(ts29571_bitrate, ' ');
+
+    if (!units) {
+        if (err) *err = "No units in bitrate";
+        return bitrate;
+    }
+
+    if (units == ts29571_bitrate) {
+        if (err) *err = "No bitrate number present";
+        return bitrate;
+    }
+
+    bitrate = strtod(ts29571_bitrate, &end);
+    if (end != units) {
+        if (err) *err = "Bitrate is not a decimal number";
+        return NAN;
+    }
+
+    SWITCH(units+1)
+    CASE("bps")
+      break;
+    CASE("Kbps")
+      bitrate *= 1e3;
+      break;
+    CASE("Mbps")
+      bitrate *= 1e6;
+      break;
+    CASE("Gbps")
+      bitrate *= 1e9;
+      break;
+    CASE("Tbps")
+      bitrate *= 1e12;
+      break;
+    DEFAULT
+      if (err) *err = "Bitrate units not valid";
+      return NAN;
+    END
+
+    return bitrate;
 }
 
 char *check_http_content_type(ogs_sbi_http_message_t http, char *content_type)

--- a/src/5gmsaf/utilities.h
+++ b/src/5gmsaf/utilities.h
@@ -39,6 +39,7 @@ extern uint16_t ascii_to_uint16(const char *str);
 extern int str_match(const char *line, const char *word_to_find);
 extern const char *get_time(time_t time_epoch);
 extern time_t str_to_time(const char *str_time);
+extern double str_to_bitrate(const char *ts29571_bitrate, const char **err);
 
 extern char *check_http_content_type(ogs_sbi_http_message_t http, char *content_type);
 

--- a/tests/msaf/meson.build
+++ b/tests/msaf/meson.build
@@ -18,6 +18,8 @@ test_msaf_sources = files('''
     pcf-cache-test.h
     sai-cache-test.c
     sai-cache-test.h
+    utilities-test.c
+    utilities-test.h
 
     tests.c
     tests.h

--- a/tests/msaf/tests.c
+++ b/tests/msaf/tests.c
@@ -15,6 +15,7 @@
 /* Unit test includes */
 #include "pcf-cache-test.h"
 #include "sai-cache-test.h"
+#include "utilities-test.h"
 
 #include "tests.h"
 
@@ -22,7 +23,8 @@ static struct {
     abts_suite *(*func)(abts_suite *suite);
 } alltests[] = {
     {test_pcf_cache},
-    {test_sai_cache}
+    {test_sai_cache},
+    {test_utilities}
 };
 
 abts_suite *tests_run(abts_suite *suite)

--- a/tests/msaf/utilities-test.c
+++ b/tests/msaf/utilities-test.c
@@ -1,0 +1,193 @@
+/*
+ * License: 5G-MAG Public License (v1.0)
+ * Author: David Waring
+ * Copyright: (C) 2023 British Broadcasting Corporation
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+/* System includes */
+#include <math.h>
+
+/* Open5GS includes */
+#include "test-common.h"
+
+/* MSAF includes */
+#include "utilities.h"
+
+/* Test includes */
+#include "utilities-test.h"
+
+#define ABTS_PTR_NULL(a, b) ABTS_PTR_EQUAL((a), (b), NULL)
+#define ABTS_DOUBLE_NOT_NAN(a, b) do { char *_ab_msg = ogs_msprintf("Double is not NaN failed, saw " #b " is %f", b); ABTS_ASSERT((a), _ab_msg, !isnan(b)); ogs_free(_ab_msg); } while (0)
+#define ABTS_DOUBLE_IS_NAN(a, b) do { char *_ab_msg = ogs_msprintf("Double is NaN failed, saw " #b " is %f", b); ABTS_ASSERT((a), _ab_msg, isnan(b)); ogs_free(_ab_msg); } while (0)
+#define ABTS_DOUBLE_EQUAL(a, b, c) do { char *_ab_msg = ogs_msprintf("Double values are equal failed, saw " #b " (%f) != " #c " (%f)", (b), (c)); ABTS_ASSERT((a), _ab_msg, (b) == (c)); ogs_free(_ab_msg); } while (0)
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* ifdef __cplusplus */
+
+/* Test good bps bitrate */
+static void test_utilities_str_to_bitrate_bps(abts_case *tc, void *data)
+{
+    const char *err = NULL;
+    double bitrate;
+
+    bitrate = str_to_bitrate("10.0 bps", &err);
+
+    ABTS_PTR_NULL(tc, err);
+    ABTS_DOUBLE_NOT_NAN(tc, bitrate);
+    ABTS_DOUBLE_EQUAL(tc, bitrate, 10.0);
+}
+
+/* Test good Kbps bitrate */
+static void test_utilities_str_to_bitrate_Kbps(abts_case *tc, void *data)
+{
+    const char *err = NULL;
+    double bitrate;
+
+    bitrate = str_to_bitrate("10.0 Kbps", &err);
+
+    ABTS_PTR_NULL(tc, err);
+    ABTS_DOUBLE_NOT_NAN(tc, bitrate);
+    ABTS_DOUBLE_EQUAL(tc, bitrate, 10000.0);
+}
+
+/* Test good Mbps bitrate */
+static void test_utilities_str_to_bitrate_Mbps(abts_case *tc, void *data)
+{
+    const char *err = NULL;
+    double bitrate;
+
+    bitrate = str_to_bitrate("10.0 Mbps", &err);
+
+    ABTS_PTR_NULL(tc, err);
+    ABTS_DOUBLE_NOT_NAN(tc, bitrate);
+    ABTS_DOUBLE_EQUAL(tc, bitrate, 10000000.0);
+}
+
+/* Test good Gbps bitrate */
+static void test_utilities_str_to_bitrate_Gbps(abts_case *tc, void *data)
+{
+    const char *err = NULL;
+    double bitrate;
+
+    bitrate = str_to_bitrate("10.0 Gbps", &err);
+
+    ABTS_PTR_NULL(tc, err);
+    ABTS_DOUBLE_NOT_NAN(tc, bitrate);
+    ABTS_DOUBLE_EQUAL(tc, bitrate, 10000000000.0);
+}
+
+/* Test good Tbps bitrate */
+static void test_utilities_str_to_bitrate_Tbps(abts_case *tc, void *data)
+{
+    const char *err = NULL;
+    double bitrate;
+
+    bitrate = str_to_bitrate("10.0 Tbps", &err);
+
+    ABTS_PTR_NULL(tc, err);
+    ABTS_DOUBLE_NOT_NAN(tc, bitrate);
+    ABTS_DOUBLE_EQUAL(tc, bitrate, 10000000000000.0);
+}
+
+/* Test bad bitrate (no units) */
+static void test_utilities_str_to_bitrate_no_units(abts_case *tc, void *data)
+{
+    const char *err = NULL;
+    double bitrate;
+
+    bitrate = str_to_bitrate("10.0", &err);
+
+    ABTS_DOUBLE_IS_NAN(tc, bitrate);
+    ABTS_PTR_NOTNULL(tc, err);
+}
+
+/* Test bad bitrate (unknown units) */
+static void test_utilities_str_to_bitrate_bad_units(abts_case *tc, void *data)
+{
+    const char *err = NULL;
+    double bitrate;
+
+    bitrate = str_to_bitrate("10.0 rubbish", &err);
+
+    ABTS_DOUBLE_IS_NAN(tc, bitrate);
+    ABTS_PTR_NOTNULL(tc, err);
+}
+
+/* Test bad bitrate (no number) */
+static void test_utilities_str_to_bitrate_no_number(abts_case *tc, void *data)
+{
+    const char *err = NULL;
+    double bitrate;
+
+    bitrate = str_to_bitrate(" bps", &err);
+
+    ABTS_DOUBLE_IS_NAN(tc, bitrate);
+    ABTS_PTR_NOTNULL(tc, err);
+}
+
+/* Test good bitrate (int not float) */
+static void test_utilities_str_to_bitrate_int_number(abts_case *tc, void *data)
+{
+    const char *err = NULL;
+    double bitrate;
+
+    bitrate = str_to_bitrate("10 bps", &err);
+
+    ABTS_PTR_NULL(tc, err);
+    ABTS_DOUBLE_NOT_NAN(tc, bitrate);
+    ABTS_DOUBLE_EQUAL(tc, bitrate, 10.0);
+}
+
+/* Test bad bitrate (bad number format) */
+static void test_utilities_str_to_bitrate_bad_number(abts_case *tc, void *data)
+{
+    const char *err = NULL;
+    double bitrate;
+
+    bitrate = str_to_bitrate("garbage bps", &err);
+
+    ABTS_DOUBLE_IS_NAN(tc, bitrate);
+    ABTS_PTR_NOTNULL(tc, err);
+}
+
+static struct {
+    void (*func)(abts_case *tc, void *data);
+} test_cases[] = {
+    /* str_to_bitrate() tests */
+    {test_utilities_str_to_bitrate_bps},
+    {test_utilities_str_to_bitrate_Kbps},
+    {test_utilities_str_to_bitrate_Mbps},
+    {test_utilities_str_to_bitrate_Gbps},
+    {test_utilities_str_to_bitrate_Tbps},
+    {test_utilities_str_to_bitrate_no_units},
+    {test_utilities_str_to_bitrate_bad_units},
+    {test_utilities_str_to_bitrate_no_number},
+    {test_utilities_str_to_bitrate_int_number},
+    {test_utilities_str_to_bitrate_bad_number}
+};
+
+abts_suite *test_utilities(abts_suite *suite)
+{
+    int i;
+    msaf_sai_cache_t *cache = NULL;
+
+    suite = ADD_SUITE(suite)
+
+    for (i=0; i<(sizeof(test_cases)/sizeof(test_cases[0])); i++) {
+        abts_run_test(suite, test_cases[i].func, &cache);
+    }
+
+    return suite;
+}
+
+#ifdef __cplusplus
+}
+#endif /* ifdef __cplusplus */
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/tests/msaf/utilities-test.h
+++ b/tests/msaf/utilities-test.h
@@ -1,0 +1,30 @@
+/*
+ * License: 5G-MAG Public License (v1.0)
+ * Author: David Waring
+ * Copyright: (C) 2023 British Broadcasting Corporation
+ *
+ * For full license terms please see the LICENSE file distributed with this
+ * program. If this file is missing then the license can be retrieved from
+ * https://drive.google.com/file/d/1cinCiA778IErENZ3JN52VFW-1ffHpx7Z/view
+*/
+
+#ifndef _TESTS_MSAF_UTILITIES_TEST_H
+#define _TESTS_MSAF_UTILITIES_TEST_H
+
+/* Open5GS includes */
+#include "test-common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* ifdef __cplusplus */
+
+abts_suite *test_utilities(abts_suite *suite);
+
+#ifdef __cplusplus
+}
+#endif /* ifdef __cplusplus */
+
+#endif /* ifndef _TESTS_MSAF_UTILITIES_TEST_H */
+
+/* vim:ts=8:sts=4:sw=4:expandtab:
+ */

--- a/tools/python3/lib/rt_m1_client/types.py
+++ b/tools/python3/lib/rt_m1_client/types.py
@@ -566,7 +566,7 @@ class BitRate(object):
 
     @staticmethod
     def __parseBitrateString(br: str) -> float:
-        val,units = br.split(' ',1)
+        val,units = (br.split(' ',1) + [None])[:2]
         val = float(val)
         if units not in ['bps', 'Kbps', 'Mbps', 'Gbps', 'Tbps', 'Pbps']:
             raise ValueError('BitRate string must have units of bps, Kbps, Mbps, Gbps, Tbps or Pbps')


### PR DESCRIPTION
These fix issues with the validation of fields in the Policy Templates where the field type is a string restricted by a regex in the OpenAPI and fixes a bug in number range validation for integer types.

This addresses #120, #121, #122  and #124.
