### PR TITLE
Bug-fix: Dynamic policies

### DIFF
--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -536,6 +536,14 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                 char *pol_temp;
                                 const char *parse_err;
 
+                                if (!msaf_self()->config.open5gsIntegration_flag) {
+                                    const char *err = "Policy Templates are not available on this instance of the 5GMS Application Function.";
+                                    ogs_error("%s",err);
+                                    ogs_error("To allow Policy Templates please set open5gsIntegration to true in the configuration file and point the nrf section to a valid 5G core.");
+                                    ogs_assert(true == nf_server_send_error(stream, 400, 2, message, "Problem adding the policy template.", err, NULL, api, app_meta));
+                                    break;
+                                }
+
                                 policy_template = cJSON_Parse(request->http.content);
                                 pol_temp = cJSON_Print(policy_template);
                                 ogs_debug("Requested Policy Template: %s", pol_temp);

--- a/src/5gmsaf/msaf-m5-sm.c
+++ b/src/5gmsaf/msaf-m5-sm.c
@@ -229,7 +229,7 @@ void msaf_m5_state_functional(ogs_fsm_t *s, msaf_event_t *e)
 
                                 const char *err = "Problem in obtaining the information required to create the Dynamic Policy";
                                 ogs_error("%s", err);
-                                ogs_assert(true == nf_server_send_error(stream, 400, 1, message, "Creation of the Dynamic Policy failed.", err, NULL, m5_dynamicpolicy_api, app_meta));
+                                ogs_assert(true == nf_server_send_error(stream, 400, 0, message, "Creation of the Dynamic Policy failed.", err, NULL, m5_dynamicpolicy_api, app_meta));
                                 cJSON_Delete(dynamic_policy);
                                 break;
                             }


### PR DESCRIPTION
These are a set of bug fixes for issues arising from the testing of dynamic policies for 5GMS Application Function v1.4.0.

These fixes include:
- Improve parsing of DynamicPolicy request to catch cases where the DynamicPolicy holds values we cannot deal with.
  - Fix for #127
- Do not allow Policy Templates to be defined when open5gsIntegration flag is not true in the configuration file.
  - Fix for #126

