### PR TITLE
Use new paths for Open5GS OpenAPI generator script and templates

### DIFF
--- a/src/5gmsaf/5G_APIs-overrides/TS26512_M1_MetricsReportingProvisioning.yaml
+++ b/src/5gmsaf/5G_APIs-overrides/TS26512_M1_MetricsReportingProvisioning.yaml
@@ -1,0 +1,148 @@
+openapi: 3.0.0
+info:
+  title: M1_MetricsReportingProvisioning
+  version: 2.1.0
+  description: |
+    5GMS AF M1 Metrics Reporting Provisioning API
+    © 2023, 3GPP Organizational Partners (ARIB, ATIS, CCSA, ETSI, TSDSI, TTA, TTC).
+    All rights reserved.
+tags:
+  - name: M1_MetricsReportingProvisioning
+    description: '5G Media Streaming: Provisioning (M1) APIs: Metrics Reporting Provisioning'
+externalDocs:
+  description: 'TS 26.512 V17.6.0; 5G Media Streaming (5GMS); Protocols'
+  url: 'https://www.3gpp.org/ftp/Specs/archive/26_series/26.512/'
+servers:
+  - url: '{apiRoot}/3gpp-m1/v2'
+    variables:
+      apiRoot:
+        default: https://example.com
+        description: See 3GPP TS 29.512 clause 6.1.
+paths:
+  /provisioning-sessions/{provisioningSessionId}/metrics-reporting-configurations:
+    parameters:
+      - name: provisioningSessionId
+        in: path
+        required: true
+        schema: 
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        description: 'The resource identifier of an existing Provisioning Session.'
+    post:
+      operationId: activateMetricsReporting
+      summary: 'Activate the Metrics reporting procedure for the specified Provisioning Session by providing the Metrics Reporting Configuration'
+      requestBody:
+        description: 'A JSON representation of a Metrics Reporting Configuration'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetricsReportingConfiguration'
+      responses:
+        '201':
+          description: 'Metrics Reporting Configuration Created'
+          headers:
+            Location:
+              description: 'URL of the newly created Metrics Reporting Configuration (same as request URL).'
+              required: true
+              schema:
+                $ref: 'TS26512_CommonData.yaml#/components/schemas/AbsoluteUrl'
+  /provisioning-sessions/{provisioningSessionId}/metrics-reporting-configurations/{metricsReportingConfigurationId}:
+    parameters:
+      - name: provisioningSessionId
+        in: path
+        required: true
+        schema: 
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        description: 'The resource identifier of an existing Provisioning Session.'
+      - name: metricsReportingConfigurationId
+        in: path
+        required: true
+        schema: 
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        description: 'The resource identifier of a Metrics Reporting Configuration.'
+    get:
+      operationId: retrieveMetricsReportingConfiguration
+      summary: 'Retrieve the specified Metrics Reporting Configuration of the specified Provisioning Session'
+      responses:
+        '200':
+          description: 'Success'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsReportingConfiguration'
+    put:
+      operationId: updateMetricsReportingConfiguration
+      summary: 'Update the specified Metrics Reporting Configuration for the specified Provisioning Session'
+      requestBody:
+        description: 'A JSON representation of a Metrics Reporting Configuration'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetricsReportingConfiguration'
+      responses:
+        '204':
+          description: 'Updated Metrics Reporting Configuration'
+        '404':
+          description: 'Not Found'
+    patch:
+      operationId: patchMetricsReportingConfiguration
+      summary: 'Patch the specified Metrics Reporting Configuration for the specified Provisioning Session'
+      requestBody:
+        description: 'A JSON representation of a Metrics Reporting Configuration'
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/MetricsReportingConfiguration'
+          application/json-patch+json:
+            schema:
+              $ref: '#/components/schemas/MetricsReportingConfiguration'
+      responses:
+        '200':
+          description: 'Patched Metrics Reporting Configuration'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetricsReportingConfiguration'
+        '404':
+          description: 'Not Found'
+    delete:
+      operationId: destroyMetricsReportingConfiguration
+      summary: 'Destroy the specified Metrics Reporting Configuration of the specified Provisioning Session'
+      responses:
+        '204':
+          description: 'Destroyed Metrics Reporting Configuration'
+        '404':
+          description: 'Not Found'    
+components:
+  schemas:
+    MetricsReportingConfiguration:
+      type: object
+      description: "A representation of a Metrics Reporting Configuration resource."
+      required:
+        - metricsReportingConfigurationId
+        - samplingPeriod
+      properties:
+        metricsReportingConfigurationId:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        scheme:
+          $ref: 'TS29571_CommonData.yaml#/components/schemas/Uri'
+        dataNetworkName:
+          $ref: 'TS29571_CommonData.yaml#/components/schemas/Dnn'
+        reportingInterval:
+          $ref: 'TS29571_CommonData.yaml#/components/schemas/DurationSec'
+        samplePercentage:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/Percentage'
+        urlFilters:
+          type: array
+          items:
+            type: string
+          minItems: 1
+        samplingPeriod:
+          $ref: 'TS29571_CommonData.yaml#/components/schemas/DurationSec'
+        metrics:
+          type: array
+          items:
+            type: string
+          minItems: 1

--- a/src/5gmsaf/5G_APIs-overrides/TS26512_M1_MetricsReportingProvisioning.yaml
+++ b/src/5gmsaf/5G_APIs-overrides/TS26512_M1_MetricsReportingProvisioning.yaml
@@ -125,7 +125,9 @@ components:
         - samplingPeriod
       properties:
         metricsReportingConfigurationId:
-          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+          readOnly: true
+          allOf:
+            - $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
         scheme:
           $ref: 'TS29571_CommonData.yaml#/components/schemas/Uri'
         dataNetworkName:

--- a/src/5gmsaf/5G_APIs-overrides/TS26512_M5_DynamicPolicies.yaml
+++ b/src/5gmsaf/5G_APIs-overrides/TS26512_M5_DynamicPolicies.yaml
@@ -1,0 +1,161 @@
+openapi: 3.0.0
+info:
+  title: M5_DynamicPolicies
+  version: 2.0.2
+  description: |
+    5GMS AF M5 Dynamic Policy API
+    © 2023, 3GPP Organizational Partners (ARIB, ATIS, CCSA, ETSI, TSDSI, TTA, TTC).
+    All rights reserved.
+tags:
+  - name: M5_DynamicPolicies
+    description: '5G Media Streaming: Media Session Handling (M5) APIs: Dynamic Policies'
+externalDocs:
+  description: 'TS 26.512 V17.6.0; 5G Media Streaming (5GMS); Protocols'
+  url: 'https://www.3gpp.org/ftp/Specs/archive/26_series/26.512/'
+servers:
+  - url: '{apiRoot}/3gpp-m5/v2'
+    variables:
+      apiRoot:
+        default: https://example.com
+        description: See 3GPP TS 29.512 clause 6.1.
+paths:
+  /dynamic-policies:
+    post:
+      operationId: createDynamicPolicy
+      summary: 'Create (and optionally upload) a new Dynamic Policy resource'
+      requestBody:
+        description: 'An optional JSON representation of a Dynamic Policy resource'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DynamicPolicy'
+      responses:
+        '201':
+          description: 'Created Dynamic Policy Resource'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DynamicPolicy'
+          headers:
+            Location:
+              description: 'The URL of the newly created Dynamic Policy resource'
+              required: true
+              schema:
+                $ref: 'TS26512_CommonData.yaml#/components/schemas/AbsoluteUrl'
+        '400':
+          description: 'Bad Request'
+        '401':
+          description: 'Unauthorized'
+ 
+  /dynamic-policies/{dynamicPolicyId}:
+    parameters:
+      - name: dynamicPolicyId
+        description: 'The resource identifier of a Dynamic Policy resource'
+        in: path
+        required: true
+        schema:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+    get:
+      operationId: retrieveDynamicPolicy
+      summary: 'Retrieve an existing Dynamic Policy resource'
+      responses:
+        '200':
+          description: 'Success'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DynamicPolicy'
+        '400':
+          description: 'Bad Request'
+        '401':
+          description: 'Unauthorized'
+        '404':
+          description: 'Not Found'
+    put:
+      operationId: updateDynamicPolicy
+      summary: 'Update an existing Dynamic Policy resource'
+      requestBody:
+        description: 'A replacement JSON representation of a Dynamic Policy resource'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DynamicPolicy'
+      responses:
+        '400':
+          description: 'Bad Request'
+        '401':
+          description: 'Unauthorized'
+        '404':
+          description: 'Not found'
+    patch:
+      operationId: patchDynamicPolicy
+      summary: 'Patch an existing Dynamic Policy resource'
+      requestBody:
+        description: 'A JSON patch to a Dynamic Policy resource'
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/DynamicPolicy'
+          application/json-patch+json:
+            schema:
+              $ref: '#/components/schemas/DynamicPolicy'
+      responses:
+        '200':
+          description: 'Patched Dynamic Policy'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DynamicPolicy'
+        '204':
+          description: 'Patched Dynamic Policy'
+        '400':
+          description: 'Bad Request'
+        '401':
+          description: 'Unauthorized'
+        '404':
+          description: 'Not found'
+    delete:
+      operationId: destroyDynamicPolicy
+      summary: 'Destroy an existing Dynamic Policy resource'
+      responses:
+        '204':
+          description: 'Destroyed Dynamic Policy'
+        '400':
+          description: 'Bad Request'
+        '401':
+          description: 'Unauthorized'
+        '404':
+          description: 'Not Found'
+components:
+  schemas:
+    DynamicPolicy:
+      description: "A representation of a Dynamic Policy resource."
+      type: object
+      required:
+        - dynamicPolicyId
+        - policyTemplateId
+        - serviceDataFlowDescriptions
+        - provisioningSessionId
+      properties:
+        dynamicPolicyId:
+          readOnly: true
+          allOf:
+            - $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        policyTemplateId:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        serviceDataFlowDescriptions:
+          type: array
+          items: 
+            $ref: 'TS26512_CommonData.yaml#/components/schemas/ServiceDataFlowDescription'
+        mediaType:
+          $ref: 'TS29514_Npcf_PolicyAuthorization.yaml#/components/schemas/MediaType'
+        provisioningSessionId:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        qosSpecification:
+          $ref: 'TS26512_CommonData.yaml#/components/schemas/M5QoSSpecification'
+        enforcementMethod:
+          type: string
+        enforcementBitRate:
+          type: integer

--- a/src/5gmsaf/generator-5gmsaf
+++ b/src/5gmsaf/generator-5gmsaf
@@ -141,7 +141,9 @@ if [ ! -d "$scriptdir/openapi" ]; then
     mkdir "$scriptdir/openapi"
 fi
 
-if ! "$scriptdir/../../subprojects/rt-common-shared/5gms/scripts/generate_openapi" -a "${APIS}" -b "${BRANCH}" -c "$scriptdir/config.yaml" -l c -d "$scriptdir/openapi" -g 6.4.0 -y "$scriptdir/fix_openapi_yaml.py" -p "MSAF_API"; then
+rt_common_shared="$scriptdir/../../subprojects/rt-common-shared"
+
+if ! "$rt_common_shared/open5gs-tools/scripts/generate_openapi" -a "${APIS}" -b "${BRANCH}" -o "$scriptdir/openapi-extra-yaml:$rt_common_shared/5gms/5G_APIs-overrides:$rt_common_shared/open5gs-tools/5G_APIs-overrides" -c "$scriptdir/config.yaml" -l c -d "$scriptdir/openapi" -g 6.4.0 -y "$scriptdir/fix_openapi_yaml.py" -p "MSAF_API"; then
     echo "Error: Failed to generate OpenAPI model" 1>&2
     exit 1
 fi

--- a/src/5gmsaf/generator-5gmsaf
+++ b/src/5gmsaf/generator-5gmsaf
@@ -143,7 +143,7 @@ fi
 
 rt_common_shared="$scriptdir/../../subprojects/rt-common-shared"
 
-if ! "$rt_common_shared/open5gs-tools/scripts/generate_openapi" -a "${APIS}" -b "${BRANCH}" -o "$scriptdir/openapi-extra-yaml:$rt_common_shared/5gms/5G_APIs-overrides:$rt_common_shared/open5gs-tools/5G_APIs-overrides" -c "$scriptdir/config.yaml" -l c -d "$scriptdir/openapi" -g 6.4.0 -y "$scriptdir/fix_openapi_yaml.py" -p "MSAF_API"; then
+if ! "$rt_common_shared/open5gs-tools/scripts/generate_openapi" -a "${APIS}" -b "${BRANCH}" -o "$scriptdir/openapi-extra-yaml:$scriptdir/5G_APIs-overrides:$rt_common_shared/5gms/5G_APIs-overrides" -c "$scriptdir/config.yaml" -l c -d "$scriptdir/openapi" -g 6.4.0 -y "$scriptdir/fix_openapi_yaml.py" -p "MSAF_API"; then
     echo "Error: Failed to generate OpenAPI model" 1>&2
     exit 1
 fi

--- a/src/5gmsaf/openapi-extra-yaml/Maf_Management.yaml
+++ b/src/5gmsaf/openapi-extra-yaml/Maf_Management.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  title: Maf_Management
+  version: 1.0.0
+  description: |
+    5GMS AF Maf_Management API
+    Copyright © 2023 British Broadcasting Corporation.
+    All rights reserved.
+tags:
+  - name: Maf_Management
+    description: '5G Media Streaming: AF Management API'
+externalDocs:
+  description: '5G-MAG Reference Tools - 5GMS Application Function'
+  url: 'https://github.com/5G-MAG/rt-common-shared/tree/main/5gms/5G_APIs-overrides'
+servers:
+  - url: '{apiRoot}/5gmag-rt-management/v1'
+    variables:
+      apiRoot:
+        default: https://example.com
+        description: See https://github.com/5G-MAG/rt-5gms-application-function/.
+paths:
+  /provisioning-sessions:
+    get:
+      operationId: enumerateProvisioningSessions
+      summary: 'Retrieve a list of current Provisioning Sessions.'
+      responses:
+        '200':
+          description: 'Success'
+          content:
+            application/json:
+              schema:
+                type: array
+                description: 'A list of current Provisioning Session resource identifiers.'
+                items:
+                  $ref: 'TS26512_CommonData.yaml#/components/schemas/ResourceId'
+        '500':
+          # Internal Server Error
+          $ref: 'TS29571_CommonData.yaml#/components/responses/500'
+        '503':
+          # Service Unavailable
+          $ref: 'TS29571_CommonData.yaml#/components/responses/503'
+        default:
+          $ref: 'TS29571_CommonData.yaml#/components/responses/default'


### PR DESCRIPTION
This is the rt-5gms-application-function counter-part PR to 5G-MAG/rt-common-shared#34.

This updates the 5GMS Application Function to use the new locations for the OpenAPI generator script and templates directories.