### PR TITLE
Location header included for creation of Metrics Configuration

### DIFF
--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -589,6 +589,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                             ogs_assert(response);
                                             nf_server_populate_response(response, 0, NULL, 201);
                                             ogs_assert(true == ogs_sbi_server_send_response(stream, response));
+                                            ogs_free(location);
                                         } else {
                                             char *err;
                                             err = ogs_msprintf("Failed to create MetricsReportingConfiguration for provisioning session [%s]", message->h.resource.component[1]);

--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -582,7 +582,10 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
 
                                         if (msaf_new_metrics_config) {
                                             ogs_sbi_response_t *response;
-                                            response = nf_server_new_response(NULL, NULL, 0, NULL, 0, NULL, api, app_meta);
+
+                                            char *location = ogs_msprintf("%s/%s", request->h.uri, msaf_new_metrics_config->config->metrics_reporting_configuration_id);
+
+                                            response = nf_server_new_response(location, NULL, 0, NULL, 0, NULL, api, app_meta);
                                             ogs_assert(response);
                                             nf_server_populate_response(response, 0, NULL, 201);
                                             ogs_assert(true == ogs_sbi_server_send_response(stream, response));


### PR DESCRIPTION
This change is adressing the error of absent `Location` header from the response upon successful creation of Metrics Configuration at M1 interface.
Related issue: https://github.com/5G-MAG/rt-5gms-application-function/issues/140