### PR TITLE
QoE Metrics Reporting | Handling of missing scheme value

### DIFF
--- a/src/5gmsaf/service-access-information.c
+++ b/src/5gmsaf/service-access-information.c
@@ -178,7 +178,7 @@ msaf_context_service_access_information_create(msaf_provisioning_session_t *prov
 
             char *scheme = msaf_strdup(metrics_config->config->scheme);
             if (!scheme || strlen(scheme) == 0) {
-                free(scheme);
+                if (scheme) ogs_free(scheme);
                 scheme = msaf_strdup("urn:3GPP:ns:PSS:DASH:QM10");
             }
 

--- a/src/5gmsaf/service-access-information.c
+++ b/src/5gmsaf/service-access-information.c
@@ -176,12 +176,18 @@ msaf_context_service_access_information_create(msaf_provisioning_session_t *prov
                 }
             }
 
+            char *scheme = msaf_strdup(metrics_config->config->scheme);
+            if (!scheme || strlen(scheme) == 0) {
+                free(scheme);
+                scheme = msaf_strdup("urn:3GPP:ns:PSS:DASH:QM10");
+            }
+
             msaf_api_service_access_information_resource_client_metrics_reporting_configurations_inner_t *cmrc_inner =
                     msaf_api_service_access_information_resource_client_metrics_reporting_configurations_inner_create(
                             msaf_strdup(metrics_config->config->metrics_reporting_configuration_id),
                             cmrc_svr_list,
                             NULL,
-                            msaf_strdup(metrics_config->config->scheme),
+                            scheme,
                             msaf_strdup(metrics_config->config->data_network_name),
                             !!metrics_config->config->reporting_interval,
                             metrics_config->config->reporting_interval?*metrics_config->config->reporting_interval:0,


### PR DESCRIPTION
## Description

This PR adds value checking for provisioned metrics configuration's `scheme`. If the value is missing from M1 *Create* operation, it will be assigned with `urn:‌3GPP:‌ns:‌PSS:‌DASH:‌QM10` scheme.

Note that according to TS26.512 (v17.7) `scheme` is not mandatory field for M1 Metrics  *Create* operation (Table 7.8.3-1). However it's required for the `clientMetricsReportingConfigurations` as part of Service Access Information (Table 11.2.3.1-1).

## Related Issue
#151 