### PR TITLE
Fixed parsing client id value from QoE metrics

### DIFF
--- a/src/5gmsaf/msaf-m5-sm.c
+++ b/src/5gmsaf/msaf-m5-sm.c
@@ -793,7 +793,7 @@ void msaf_m5_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                     if (request->http.content) {
                                         char *reportTime = parseXmlField(request->http.content, "reportTime");
                                         char *recordingSessionId = parseXmlField(request->http.content, "recordingSessionId");
-                                        char *clientId = parseXmlField(request->http.content, "clientId");
+                                        char *clientId = parseXmlField(request->http.content, "clientID");
 
                                         if (msaf_data_collection_store(message->h.resource.component[1], "metrics_reports", clientId, recordingSessionId, reportTime, "xml", request->http.content)) {
                                             ogs_sbi_response_t *response;


### PR DESCRIPTION
## Description

Fixes parsing of `clientID` field of incoming metrics data.

Related issue: https://github.com/5G-MAG/rt-5gms-application-function/issues/154