### PR TITLE
Bug-fix: Response message for activateConsumptionReporting operation at M1

### DIFF
--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -548,9 +548,9 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                     } else {
                                         ogs_sbi_response_t *response;
 
-                                        response = nf_server_new_response(NULL, NULL,  0, NULL, 0, NULL, api, app_meta);
+                                        response = nf_server_new_response(message->h.uri, NULL,  0, NULL, 0, NULL, api, app_meta);
                                         ogs_assert(response);
-                                        nf_server_populate_response(response, 0, NULL, 204);
+                                        nf_server_populate_response(response, 0, NULL, 201);
                                         ogs_assert(true == ogs_sbi_server_send_response(stream, response));
                                     }
                                 }


### PR DESCRIPTION
This fixes the HTTP response message to the _activateConsumptionReporting_ operation at reference point M1 in line with the YAML API specification in TS 26.512 V17.7.0:
- Add missing `Location` header.
- Change the status code from *204 No Content* to *201 Created*.

Fixes #156 and #157 