### PR TITLE
Reflect the enabled state of PolicyTemplate provisioning in the OPTIONS method

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@
 # Meson module fs and its functions like fs.hash_file require atleast meson 0.59.0 
 
 project('rt-5gms-application-function', 'c',
-    version : '1.4.1',
+    version : '1.4.2',
     license : '5G-MAG Public',
     meson_version : '>= 0.63.0',
     default_options : [

--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -1719,13 +1719,13 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                                 }
 
                                             } else {
-                                                static const char methods[] = OGS_SBI_HTTP_METHOD_POST ", "
+                                                static const char methods_feature_enabled[] = OGS_SBI_HTTP_METHOD_POST ", "
                                                                               OGS_SBI_HTTP_METHOD_OPTIONS;
-                                                static const char disabled_methods[] = OGS_SBI_HTTP_METHOD_OPTIONS;
+                                                static const char methods_feature_disabled[] = OGS_SBI_HTTP_METHOD_OPTIONS;
                                                 if (!msaf_self()->config.open5gsIntegration_flag) {
-                                                    response = nf_server_new_response(request->h.uri, NULL,  0, NULL, 0, disabled_methods, m1_policytemplatesprovisioning_api, app_meta);
+                                                    response = nf_server_new_response(request->h.uri, NULL,  0, NULL, 0, methods_feature_disabled, m1_policytemplatesprovisioning_api, app_meta);
                                                 } else {
-                                                    response = nf_server_new_response(request->h.uri, NULL,  0, NULL, 0, methods, m1_policytemplatesprovisioning_api, app_meta);
+                                                    response = nf_server_new_response(request->h.uri, NULL,  0, NULL, 0, methods_feature_enabled, m1_policytemplatesprovisioning_api, app_meta);
                                                 }
                                                 nf_server_populate_response(response, 0, NULL, 204);
                                                 ogs_assert(response);

--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -1721,7 +1721,12 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                             } else {
                                                 static const char methods[] = OGS_SBI_HTTP_METHOD_POST ", "
                                                                               OGS_SBI_HTTP_METHOD_OPTIONS;
-                                                response = nf_server_new_response(request->h.uri, NULL,  0, NULL, 0, methods, m1_policytemplatesprovisioning_api, app_meta);
+                                                static const char disabled_methods[] = OGS_SBI_HTTP_METHOD_OPTIONS;
+                                                if (!msaf_self()->config.open5gsIntegration_flag) {
+                                                    response = nf_server_new_response(request->h.uri, NULL,  0, NULL, 0, disabled_methods, m1_policytemplatesprovisioning_api, app_meta);
+                                                } else {
+                                                    response = nf_server_new_response(request->h.uri, NULL,  0, NULL, 0, methods, m1_policytemplatesprovisioning_api, app_meta);
+                                                }
                                                 nf_server_populate_response(response, 0, NULL, 204);
                                                 ogs_assert(response);
                                                 ogs_assert(true == ogs_sbi_server_send_response(stream, response));


### PR DESCRIPTION
Fixes 5G-MAG/rt-5gms-application-provider#45

If the `open5gsIntegration` YAML configuration file variable is not true then this removes the `Allow: POST` response header from the headers returned for the `OPTIONS` method on the `.../provisioning-sessions/{provisioningSessionId}/policy-templates` M1 API path. This allows the UI to detect if provisioning of PolicyTemplates will be allowed or not.