### PR TITLE
Uplift to 3GPP TS 26.512 V17.9.1

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,3 @@
 option('latest_apis', type: 'boolean', value: false)
-option('fiveg_api_approval', type: 'string', value: '102')
+option('fiveg_api_approval', type: 'string', value: '104')
 option('fiveg_api_release', type: 'string', value: '17')

--- a/src/5gmsaf/consumption-report-configuration.c
+++ b/src/5gmsaf/consumption-report-configuration.c
@@ -89,16 +89,16 @@ bool msaf_consumption_report_configuration_deregister(msaf_provisioning_session_
     return true;
 }
 
-msaf_api_consumption_reporting_configuration_t *msaf_consumption_report_configuration_parseJSON(cJSON *json /* [no-transfer, not-null] */, const char **err_out /* [out, not-null] */)
+msaf_api_consumption_reporting_configuration_t *msaf_consumption_report_configuration_parseJSON(cJSON *json /* [no-transfer, not-null] */, const char **err_out /* [out, not-null] */, char **err_param /* [out, transfer, not-null] */)
 {
     msaf_api_consumption_reporting_configuration_t *crc;
 
     *err_out = NULL;
+    *err_param = NULL;
 
-    crc = msaf_api_consumption_reporting_configuration_parseRequestFromJSON(json, err_out);
+    crc = msaf_api_consumption_reporting_configuration_parseRequestFromJSON(json, err_out, err_param);
     if (!crc) {
-        /* err_out set by parser */
-        /* *err_out = "Failed to convert JSON to a ConsumptionReportingConfiguration"; */
+        /* err_out and err_param set by parser */
         return NULL;
     }
 

--- a/src/5gmsaf/consumption-report-configuration.h
+++ b/src/5gmsaf/consumption-report-configuration.h
@@ -25,7 +25,9 @@ extern bool msaf_consumption_report_configuration_update(msaf_provisioning_sessi
 extern bool msaf_consumption_report_configuration_deregister(msaf_provisioning_session_t *session /* [no-transfer, not-null] */);
 
 extern msaf_api_consumption_reporting_configuration_t *msaf_consumption_report_configuration_parseJSON(
-                                                cJSON *json /* [no-transfer, not-null] */, const char **err_out /* [out, not-null] */);
+                                                cJSON *json /* [no-transfer, not-null] */,
+                                                const char **err_out /* [out, not-null] */,
+                                                char **err_param /* [out, transfer, not-null] */);
 extern cJSON *msaf_consumption_report_configuration_json(msaf_provisioning_session_t *session /* [no-transfer, not-null] */);
 extern char *msaf_consumption_report_configuration_body(msaf_provisioning_session_t *session /* [no-transfer, not-null] */);
 extern time_t msaf_consumption_report_configuration_last_modified(

--- a/src/5gmsaf/dynamic-policy.c
+++ b/src/5gmsaf/dynamic-policy.c
@@ -82,12 +82,13 @@ int msaf_dynamic_policy_create(cJSON *dynamicPolicy, msaf_event_t *e)
     msaf_policy_template_node_t *msaf_policy_template;
     OpenAPI_lnode_t *node = NULL;
     OpenAPI_list_t *media_component = NULL;
-    const char *reason;
+    const char *reason = NULL;
+    char *parameter = NULL;
 
-
-    dynamic_policy =  msaf_api_dynamic_policy_parseRequestFromJSON(dynamicPolicy, &reason);
+    dynamic_policy =  msaf_api_dynamic_policy_parseRequestFromJSON(dynamicPolicy, &reason, &parameter);
     if (!dynamic_policy) {
-        ogs_error("Dynamic Policy Badly formed JSON: [%s]", reason);
+        ogs_error("Dynamic Policy Badly formed JSON (at %s): [%s]", parameter, reason);
+        if (parameter) ogs_free(parameter);
         return 0;
     }
 
@@ -605,7 +606,7 @@ static void create_dynamic_policy_app_session(const ogs_sockaddr_t *pcf_address,
     pcf_session = msaf_pcf_session_new(pcf_address);
 
     if (!pcf_session) {
-        ogs_assert(true == nf_server_send_error(dynamic_policy->metadata->create_event->h.sbi.data, 401, 0, dynamic_policy->metadata->create_event->message, "Failed to create dynamic policy.", "Unable to establish connection with the PCF." , NULL, dynamic_policy->metadata->create_event->nf_server_interface_metadata, dynamic_policy->metadata->create_event->app_meta));
+        ogs_assert(true == nf_server_send_error(dynamic_policy->metadata->create_event->h.sbi.data, 401, 0, dynamic_policy->metadata->create_event->message, "Failed to create dynamic policy.", "Unable to establish connection with the PCF." , NULL, NULL, dynamic_policy->metadata->create_event->nf_server_interface_metadata, dynamic_policy->metadata->create_event->app_meta));
     }
 
     ue_net  = copy_ue_network_connection_identifier(ue_connection);
@@ -694,7 +695,7 @@ static bool app_session_change_callback(pcf_app_session_t *app_session, void *da
 
         if (dynamic_policy->metadata->create_event)
         {
-            ogs_assert(true == nf_server_send_error(dynamic_policy->metadata->create_event->h.sbi.data, 401, 0, dynamic_policy->metadata->create_event->message, "Failed to create dynamic policy.", "Unable to establish connection with the PCF." , NULL, dynamic_policy->metadata->create_event->nf_server_interface_metadata, dynamic_policy->metadata->create_event->app_meta));
+            ogs_assert(true == nf_server_send_error(dynamic_policy->metadata->create_event->h.sbi.data, 401, 0, dynamic_policy->metadata->create_event->message, "Failed to create dynamic policy.", "Unable to establish connection with the PCF." , NULL, NULL, dynamic_policy->metadata->create_event->nf_server_interface_metadata, dynamic_policy->metadata->create_event->app_meta));
             msaf_dynamic_policy_remove(dynamic_policy);
             return true;
         }
@@ -860,7 +861,7 @@ static bool bsf_retrieve_pcf_binding_callback(OpenAPI_pcf_binding_t *pcf_binding
            ogs_error("%s", err);
            ogs_assert(true == nf_server_send_error(retrieve_pcf_binding_cb_data->dyn_policy->metadata->create_event->h.sbi.data, 404, 0,
                                    retrieve_pcf_binding_cb_data->dyn_policy->metadata->create_event->message,
-                                   "PCF app session creation failed.", err, NULL,
+                                   "PCF app session creation failed.", err, NULL, NULL,
                                    retrieve_pcf_binding_cb_data->dyn_policy->metadata->create_event->nf_server_interface_metadata,
                                    retrieve_pcf_binding_cb_data->dyn_policy->metadata->create_event->app_meta));
            ogs_free(err);
@@ -875,7 +876,7 @@ static bool bsf_retrieve_pcf_binding_callback(OpenAPI_pcf_binding_t *pcf_binding
         ogs_error("%s", err);
         ogs_assert(true == nf_server_send_error(retrieve_pcf_binding_cb_data->dyn_policy->metadata->create_event->h.sbi.data, 404, 0,
                                    retrieve_pcf_binding_cb_data->dyn_policy->metadata->create_event->message,
-                                   "PCF Binding not found.", err, NULL,
+                                   "PCF Binding not found.", err, NULL, NULL,
                                    retrieve_pcf_binding_cb_data->dyn_policy->metadata->create_event->nf_server_interface_metadata,
                                    retrieve_pcf_binding_cb_data->dyn_policy->metadata->create_event->app_meta));
         ogs_free(err);

--- a/src/5gmsaf/generator-5gmsaf
+++ b/src/5gmsaf/generator-5gmsaf
@@ -122,10 +122,14 @@ cp "${scriptdir}/../../subprojects/rt-common-shared/open5gs-tools/openapi-genera
 cat >> $scriptdir/config.yaml << EOF
 importMappings:
   set: set
+  any_type: any_type
   msaf_api_set: set
+  msaf_api_any_type: any_type
 typeMappings:
   set: set
+  any_type: any_type
   msaf_api_set: set
+  msaf_api_any_type: any_type
 files:
   api-info-head.mustache:
     templateType: API
@@ -134,6 +138,22 @@ files:
     templateType: SupportingFiles
     folder: include
     destinationFilename: set.h
+  any_type.c.mustache:
+    templateType: SupportingFiles
+    folder: src
+    destinationFilename: any_type.c
+  any_type.h.mustache:
+    templateType: SupportingFiles
+    folder: include
+    destinationFilename: any_type.h
+  OpenAPI_regex.c.mustache:
+    templateType: SupportingFiles
+    folder: src
+    destinationFilename: OpenAPI_regex.c
+  OpenAPI_regex.h.mustache:
+    templateType: SupportingFiles
+    folder: include
+    destinationFilename: OpenAPI_regex.h
 EOF
 
 # call the common generate_openapi script
@@ -149,6 +169,8 @@ if ! "$rt_common_shared/open5gs-tools/scripts/generate_openapi" -a "${APIS}" -b 
 fi
  
 ln -s ../include/set.h "$scriptdir/openapi/model/msaf_api_set.h"
+ln -s ../include/OpenAPI_regex.h "$scriptdir/openapi/model/OpenAPI_regex.h"
+ln -s ../src/OpenAPI_regex.c "$scriptdir/openapi/model/OpenAPI_regex.c"
 
 # Delete any model file already in the Open5GS SBI library to avoid clashes
 for f in "$scriptdir/openapi/model"/*.[ch]; do

--- a/src/5gmsaf/meson.build
+++ b/src/5gmsaf/meson.build
@@ -22,6 +22,8 @@ sbi_openapi_inc = open5gs_project.get_variable('libsbi_openapi_model_inc')
 libscbsf_dep = svc_consumers_project.get_variable('libscbsf_dep')
 libscpcf_dep = svc_consumers_project.get_variable('libscpcf_dep')
 
+libpcre2 = dependency('libpcre2-8')
+
 latest_apis = get_option('latest_apis')
 fiveg_api_approval = get_option('fiveg_api_approval')
 fiveg_api_release = get_option('fiveg_api_release')
@@ -155,7 +157,8 @@ libmsaf_dep = declare_dependency(
                     libapp_dep,
                     libscbsf_dep,
                     libscpcf_dep,
-                    libcrypt_dep])
+                    libcrypt_dep,
+                    libpcre2])
 
 msaf_sources = files('''
     app.c

--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -1672,9 +1672,9 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                 ogs_assert(true == ogs_sbi_server_send_response(stream, response));
                                 msaf_delete_content_hosting_configuration(message->h.resource.component[1]);
                                 msaf_delete_certificates(message->h.resource.component[1]);
-                                msaf_context_provisioning_session_free(provisioning_session);
                                 msaf_consumption_report_configuration_deregister(provisioning_session);
                                 msaf_provisioning_session_hash_remove(message->h.resource.component[1]);
+                                msaf_context_provisioning_session_free(provisioning_session);
                             }
                         } else {
                             char *err;

--- a/src/5gmsaf/msaf-mgmt-sm.c
+++ b/src/5gmsaf/msaf-mgmt-sm.c
@@ -78,7 +78,7 @@ void msaf_maf_mgmt_state_functional(ogs_fsm_t *s, msaf_event_t *e)
 
             DEFAULT
                 ogs_error("Resource [%s] not found.", message->h.service.name);
-                ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_NOT_FOUND, 0, message, "Not Found.", message->h.service.name, NULL, maf_management_api, app_meta));
+                ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_NOT_FOUND, 0, message, "Not Found.", message->h.service.name, NULL, NULL, maf_management_api, app_meta));
 
             END
             break;

--- a/src/5gmsaf/msaf-sm.c
+++ b/src/5gmsaf/msaf-sm.c
@@ -97,7 +97,7 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
             rv = ogs_sbi_parse_header(message, &request->h);
             if (rv != OGS_OK) {
                 ogs_error("ogs_sbi_parse_header() failed");
-                ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, 1, NULL, "cannot parse HTTP message", NULL, NULL, NULL, app_meta));
+                ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, 1, NULL, "cannot parse HTTP message", NULL, NULL, NULL, NULL, app_meta));
                 ogs_sbi_message_free(message);
                 break;
             }
@@ -146,7 +146,7 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                 } else {
                     char *error;
                     error = ogs_msprintf("Resource [%s] not found.", request->h.uri);
-                    ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_NOT_FOUND, 1, NULL, "Not Found.", error, NULL, NULL, app_meta));
+                    ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_NOT_FOUND, 1, NULL, "Not Found.", error, NULL, NULL, NULL, app_meta));
                     ogs_free(error);
                 }
                 break;
@@ -160,7 +160,7 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                 } else {
                     char *error;
                     error = ogs_msprintf("Resource [%s] not found.", request->h.uri);
-                    ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_NOT_FOUND, 1, NULL, "Not Found.", error, NULL, NULL, app_meta));
+                    ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_NOT_FOUND, 1, NULL, "Not Found.", error, NULL, NULL, NULL, app_meta));
                     ogs_free(error);
                 }
                 break;
@@ -173,13 +173,13 @@ void msaf_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                 } else {
                     char *error;
                     error = ogs_msprintf("Resource [%s] not found.", request->h.uri);
-                    ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_NOT_FOUND, 1, NULL, "Not Found.", error, NULL, NULL, app_meta));
+                    ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_NOT_FOUND, 1, NULL, "Not Found.", error, NULL, NULL, NULL, app_meta));
                     ogs_free(error);
                 }
                 break;
             DEFAULT
                 ogs_error("Invalid API name [%s]", message->h.service.name);
-                ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, 0, message, "Invalid API name.",  message->h.service.name, NULL, NULL, app_meta));
+                ogs_assert(true == nf_server_send_error(stream, OGS_SBI_HTTP_STATUS_BAD_REQUEST, 0, message, "Invalid API name.",  message->h.service.name, NULL, NULL, NULL, app_meta));
 
             END
             if (message) ogs_sbi_message_free(message);

--- a/src/5gmsaf/network-assistance-session.c
+++ b/src/5gmsaf/network-assistance-session.c
@@ -59,7 +59,7 @@ int msaf_nw_assistance_session_create(cJSON *network_assistance_sess, msaf_event
     OpenAPI_lnode_t *node = NULL;
     OpenAPI_list_t *media_component = NULL;
 
-    nas =  msaf_api_network_assistance_session_parseRequestFromJSON(network_assistance_sess, NULL);
+    nas =  msaf_api_network_assistance_session_parseRequestFromJSON(network_assistance_sess, NULL, NULL);
     if (!nas) return 0;
 
     na_sess = msaf_network_assistance_session_init();
@@ -224,12 +224,12 @@ void msaf_nw_assistance_session_delivery_boost_update(msaf_network_assistance_se
 
         if (!pcf_session_update_app_session(na_sess->pcf_app_session, media_comps)) {
             ogs_error("Unable to send update request to the PCF");
-            ogs_assert(true == nf_server_send_error(e->h.sbi.data, 401, 0, e->message, "Creation of delivery boost failed.", "Unable to send update request to the PCF" , NULL, e->nf_server_interface_metadata, e->app_meta));
+            ogs_assert(true == nf_server_send_error(e->h.sbi.data, 401, 0, e->message, "Creation of delivery boost failed.", "Unable to send update request to the PCF" , NULL, NULL, e->nf_server_interface_metadata, e->app_meta));
         }
 
     } else {
             ogs_error("The Network Assistance Session has no associated App Session");
-            ogs_assert(true == nf_server_send_error(e->h.sbi.data, 401, 0, e->message, "Creation of delivery boost failed.", "The Network Assistance Session has no associated App Session" , NULL, e->nf_server_interface_metadata, e->app_meta));
+            ogs_assert(true == nf_server_send_error(e->h.sbi.data, 401, 0, e->message, "Creation of delivery boost failed.", "The Network Assistance Session has no associated App Session" , NULL, NULL, e->nf_server_interface_metadata, e->app_meta));
 
     }
     ogs_info("END of msaf_nw_assistance_session_update_pcf");
@@ -632,7 +632,7 @@ static bool app_session_change_callback(pcf_app_session_t *app_session, void *da
         if (na_sess->metadata->create_event)
         {
             /*
-            ogs_assert(true == nf_server_send_error(na_sess->create_event->h.sbi.data, 401, 0, na_sess->create_event->message, "Creation of the Network Assistance Session failed.", "PCF App Session creation failed" , NULL, na_sess->create_event->local.nf_server_interface_metadata, na_sess->create_event->local.app_meta));
+            ogs_assert(true == nf_server_send_error(na_sess->create_event->h.sbi.data, 401, 0, na_sess->create_event->message, "Creation of the Network Assistance Session failed.", "PCF App Session creation failed" , NULL, NULL, na_sess->create_event->local.nf_server_interface_metadata, na_sess->create_event->local.app_meta));
             */
             msaf_network_assistance_session_remove(na_sess);
             return false;
@@ -841,7 +841,7 @@ static bool bsf_retrieve_pcf_binding_callback(OpenAPI_pcf_binding_t *pcf_binding
            ogs_error("%s", err);
            ogs_assert(true == nf_server_send_error(retrieve_pcf_binding_cb_data->na_sess->metadata->create_event->h.sbi.data, 404, 0,
                                    retrieve_pcf_binding_cb_data->na_sess->metadata->create_event->message,
-                                   "PCF app session creation failed.", err, NULL,
+                                   "PCF app session creation failed.", err, NULL, NULL,
                                    retrieve_pcf_binding_cb_data->na_sess->metadata->create_event->nf_server_interface_metadata,
                                    retrieve_pcf_binding_cb_data->na_sess->metadata->create_event->app_meta));
            ogs_free(err);
@@ -856,7 +856,7 @@ static bool bsf_retrieve_pcf_binding_callback(OpenAPI_pcf_binding_t *pcf_binding
         ogs_error("%s", err);
         ogs_assert(true == nf_server_send_error(retrieve_pcf_binding_cb_data->na_sess->metadata->create_event->h.sbi.data, 404, 0,
                                    retrieve_pcf_binding_cb_data->na_sess->metadata->create_event->message,
-                                   "PCF Binding not found.", err, NULL,
+                                   "PCF Binding not found.", err, NULL, NULL,
                                    retrieve_pcf_binding_cb_data->na_sess->metadata->create_event->nf_server_interface_metadata,
                                    retrieve_pcf_binding_cb_data->na_sess->metadata->create_event->app_meta));
         ogs_free(err);

--- a/src/5gmsaf/policy-template.c
+++ b/src/5gmsaf/policy-template.c
@@ -19,9 +19,9 @@ static void msaf_policy_template_set_state_reason(msaf_api_policy_template_t *po
 
 /***** Public functions *****/
 
-msaf_api_policy_template_t *msaf_policy_template_parseFromJSON(cJSON *policy_templateJSON, const char **reason)
+msaf_api_policy_template_t *msaf_policy_template_parseFromJSON(cJSON *policy_templateJSON, const char **reason, char **parameter)
 {
-    return msaf_api_policy_template_parseRequestFromJSON(policy_templateJSON, reason);
+    return msaf_api_policy_template_parseRequestFromJSON(policy_templateJSON, reason, parameter);
 }
 
 void msaf_policy_template_set_id(msaf_api_policy_template_t *policy_template, const char *policy_template_id)
@@ -59,7 +59,7 @@ msaf_policy_template_node_t *msaf_policy_template_populate(msaf_api_policy_templ
     return msaf_policy_template;
 }
 
-bool msaf_policy_template_set_state(msaf_api_policy_template_t *policy_template, msaf_api_policy_template_state_e new_state, msaf_provisioning_session_t *provisioning_session) {
+bool msaf_policy_template_set_state(msaf_api_policy_template_t *policy_template, msaf_api_policy_template_STATE_e new_state, msaf_provisioning_session_t *provisioning_session) {
 
 
    ogs_assert(policy_template);

--- a/src/5gmsaf/policy-template.h
+++ b/src/5gmsaf/policy-template.h
@@ -21,13 +21,13 @@ extern "C" {
 
 #define msaf_policy_template_free(policy_template) msaf_api_policy_template_free(policy_template)
 
-extern bool msaf_policy_template_set_state(msaf_api_policy_template_t *policy_template, msaf_api_policy_template_state_e new_state, msaf_provisioning_session_t *provisioning_session);
+extern bool msaf_policy_template_set_state(msaf_api_policy_template_t *policy_template, msaf_api_policy_template_STATE_e new_state, msaf_provisioning_session_t *provisioning_session);
 
 extern void msaf_policy_template_set_id(msaf_api_policy_template_t *policy_template, const char *policy_template_id);
 
 extern msaf_api_policy_template_t *msaf_policy_template_create(cJSON *policy_template);
 
-extern msaf_api_policy_template_t *msaf_policy_template_parseFromJSON(cJSON *policy_templateJSON, const char **reason);
+extern msaf_api_policy_template_t *msaf_policy_template_parseFromJSON(cJSON *policy_templateJSON, const char **reason, char **parameter);
 
 extern cJSON *msaf_policy_template_convertToJSON(msaf_api_policy_template_t *policy_template);
 

--- a/src/5gmsaf/provisioning-session.h
+++ b/src/5gmsaf/provisioning-session.h
@@ -59,7 +59,7 @@ typedef struct msaf_provisioning_session_s {
 
 typedef struct msaf_application_server_state_node_s msaf_application_server_state_node_t;
 
-typedef void (*msaf_policy_template_state_change_callback)(msaf_provisioning_session_t *provisioning_session, msaf_policy_template_node_t *policy_template_node, msaf_api_policy_template_state_e new_state, void *user_data);
+typedef void (*msaf_policy_template_state_change_callback)(msaf_provisioning_session_t *provisioning_session, msaf_policy_template_node_t *policy_template_node, msaf_api_policy_template_STATE_e new_state, void *user_data);
 
 typedef struct msaf_application_server_state_ref_node_s {
     ogs_lnode_t node;
@@ -69,7 +69,7 @@ typedef struct msaf_application_server_state_ref_node_s {
 typedef struct msaf_policy_template_change_state_event_data_s {
     msaf_provisioning_session_t *provisioning_session;
     msaf_policy_template_node_t *policy_template_node;
-    msaf_api_policy_template_state_e new_state;
+    msaf_api_policy_template_STATE_e new_state;
     msaf_policy_template_state_change_callback callback;
     void *callback_user_data;
 } msaf_policy_template_change_state_event_data_t;
@@ -77,6 +77,7 @@ typedef struct msaf_policy_template_change_state_event_data_s {
 extern msaf_provisioning_session_t *msaf_provisioning_session_create(const char *provisioning_session_type, const char *asp_id, const char *external_app_id);
 extern void msaf_provisioning_session_free(msaf_provisioning_session_t *provisioning_session);
 extern msaf_provisioning_session_t *msaf_provisioning_session_find_by_provisioningSessionId(const char *provisioningSessionId);
+extern msaf_provisioning_session_t *msaf_provisioning_session_parseRequestFromJSON(cJSON *json, const char **reason, char **err_parameter);
 extern cJSON *msaf_provisioning_session_get_json(const char *provisioning_session_id);
 
 extern msaf_api_content_hosting_configuration_t *msaf_content_hosting_configuration_create(msaf_provisioning_session_t *provisioning_session);
@@ -99,7 +100,7 @@ extern void msaf_provisioning_session_certificate_hash_remove(const char *provis
 
 extern int uri_relative_check(const char *entry_point_path);
 
-extern int msaf_distribution_create(cJSON *content_hosting_config, msaf_provisioning_session_t *provisioning_session, const char **reason_ret);
+extern int msaf_distribution_create(cJSON *content_hosting_config, msaf_provisioning_session_t *provisioning_session, const char **reason_ret, char **err_parameter);
 
 extern cJSON *msaf_get_content_hosting_configuration_by_provisioning_session_id(const char *provisioning_session_id);
 
@@ -115,7 +116,7 @@ extern msaf_policy_template_node_t *msaf_provisioning_session_find_policy_templa
 
 extern msaf_policy_template_node_t *msaf_provisioning_session_get_policy_template_by_id(const char *provisioning_session_id, const char *policy_template_id);
 
-extern bool msaf_provisioning_session_send_policy_template_state_change_event(msaf_provisioning_session_t *provisioning_session,  msaf_policy_template_node_t *policy_template, msaf_api_policy_template_state_e new_state, msaf_policy_template_state_change_callback callback, void *user_data);
+extern bool msaf_provisioning_session_send_policy_template_state_change_event(msaf_provisioning_session_t *provisioning_session,  msaf_policy_template_node_t *policy_template, msaf_api_policy_template_STATE_e new_state, msaf_policy_template_state_change_callback callback, void *user_data);
 
 extern bool msaf_provisioning_session_update_policy_template(msaf_provisioning_session_t *provisioning_session, msaf_policy_template_node_t *msaf_policy_template, msaf_api_policy_template_t *policy_template);
 

--- a/src/5gmsaf/server.h
+++ b/src/5gmsaf/server.h
@@ -30,8 +30,9 @@ typedef struct nf_server_app_metadata_s {
 
 extern bool nf_server_send_error(ogs_sbi_stream_t *stream,
         int status, int number_of_components, ogs_sbi_message_t *message,
-        const char *title, const char *detail, cJSON * problem_detail, const nf_server_interface_metadata_t *interface,
-        const nf_server_app_metadata_t *app);
+        const char *title, const char *detail, cJSON * problem_detail,
+        OpenAPI_list_t *invalid_parameters,
+        const nf_server_interface_metadata_t *interface, const nf_server_app_metadata_t *app);
 
 extern ogs_sbi_response_t *nf_server_new_response(const char *location, const char *content_type, time_t last_modified, 
                                                   const char *etag, int cache_control, const char *allow_methods,
@@ -39,6 +40,7 @@ extern ogs_sbi_response_t *nf_server_new_response(const char *location, const ch
                                                   const nf_server_app_metadata_t *app);
 extern ogs_sbi_response_t *nf_server_populate_response(ogs_sbi_response_t *response, int content_length, char *content,
                                                        int status);
+extern OpenAPI_list_t *nf_server_invalid_param(char *parameter, const char *err);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes #163 

These changes, combined with 5G-MAG/rt-common-shared#39, implement the uplift to TS 26.512 and include some bug fixes for issues found during testing.

The major changes are:
1. Compliance with the TS 26.512 V17.9.1 specification.
    - No new API interfaces have been added only the existing ones have been brought inline with V17.9.1.
2. Error responses now include `invalidParameters`, where appropriate, in the ProblemReport JSON to indicate the field that caused the error.
3. Changes in the templates, implemented by PR 5G-MAG/rt-common-shared#39, have added Date-Time, Date, URL, UUID and custom *pattern* string validation to the OpenAPI generated parsers.
    - This means the AF will now be a bit stricter about the format of certain string fields passed in on the M1 and M5 API interfaces.

