### PR TITLE
Bug-fix: Update README for new dependencies and meson version consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ A list of currently supported features is available [here](https://5g-mag.github
 ## Install dependencies
 
 ```bash
-sudo apt install git python3-pip python3-venv python3-setuptools python3-wheel ninja-build build-essential flex bison git libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev curl wget default-jdk cmake
-python3 -m pip install build pyOpenSSL meson
+sudo apt install git python3-pip python3-venv python3-setuptools python3-wheel ninja-build build-essential flex bison git libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev libpcre2-dev curl wget default-jdk cmake
+sudo python3 -m pip install meson
+python3 -m pip install build pyOpenSSL
 ```
 
 ## Downloading
@@ -54,7 +55,7 @@ meson build
 ninja -C build
 ```
 
-**Note:** Errors during the `meson build` command are often caused by missing dependancies or a network issue while trying to retrieve the API files and `openapi-generator` JAR file. See the `~/rt-5gms-application-function/build/meson-logs/meson-log.txt` log file for the errors in greater detail. Search for `generator-5gmsaf` to find the start of the API fetch sequence.
+**Note:** Errors during the `meson build` command are often caused by missing dependencies or a network issue while trying to retrieve the API files and `openapi-generator` JAR file. See the `~/rt-5gms-application-function/build/meson-logs/meson-log.txt` log file for the errors in greater detail. Search for `generator-5gmsaf` to find the start of the API fetch sequence.
 
 ## Installing
 

--- a/src/5gmsaf/metrics-reporting-configuration.c
+++ b/src/5gmsaf/metrics-reporting-configuration.c
@@ -81,8 +81,7 @@ msaf_metrics_reporting_configuration_t* process_and_map_metrics_reporting_config
         provisioning_session->metrics_reporting_map = msaf_metrics_reporting_map();
     }
 
-    char *hashKey = msaf_strdup(msaf_metrics_config->config->metrics_reporting_configuration_id);
-    ogs_hash_set(provisioning_session->metrics_reporting_map, hashKey, OGS_HASH_KEY_STRING, msaf_metrics_config);
+    ogs_hash_set(provisioning_session->metrics_reporting_map, msaf_metrics_config->config->metrics_reporting_configuration_id, OGS_HASH_KEY_STRING, msaf_metrics_config);
 
     return msaf_metrics_config;
 }

--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -462,8 +462,8 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                         ogs_list_remove(&extra_domains_list, node);
                                         ogs_free(node);
                                     }
-
-                                    ogs_hash_set(msaf_provisioning_session->certificate_map, msaf_strdup(csr_cert->id), OGS_HASH_KEY_STRING, msaf_strdup(csr_cert->id));
+                                    char *csr_cert_id = msaf_strdup(csr_cert->id);
+                                    ogs_hash_set(msaf_provisioning_session->certificate_map, csr_cert_id, OGS_HASH_KEY_STRING, csr_cert_id);
                                     ogs_sbi_response_t *response;
                                     location = ogs_msprintf("%s/%s", request->h.uri, csr_cert->id);
                                     if (csr_cert->cache_control_max_age) {

--- a/src/5gmsaf/provisioning-session.c
+++ b/src/5gmsaf/provisioning-session.c
@@ -1000,7 +1000,7 @@ free_ogs_hash_entry(void *rec, const void *key, int klen, const void *value)
     free_ogs_hash_context_t *fohc = (free_ogs_hash_context_t*)rec;
     ogs_hash_set(fohc->hash, key, klen, NULL);
     fohc->value_free_fn((void*)value);
-    ogs_free((void*)key);
+    //ogs_free((void*)key);
     return 1;
 }
 


### PR DESCRIPTION
This PR make a few minor updates:
1. The README is updated to reflect the need for the PCRE v2 library (development package) when building. This is needed after the introduction of regex pattern validation where indicated for string fields in code generated from OpenAPI models.
2. The README is updated to bring the system meson build up to date for package installation (`sudo meson ...` is used for installation to system paths).
3. Some minor memory leak bugs were found when testing for 5G-MAG/rt-5gms-application-provider#48 and have been fixed here.