### PR TITLE
Change rt-5gc-service-consumers to the v1.0.x branch to maintain Open5GS 2.6.4 compatibility

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@
 # Meson module fs and its functions like fs.hash_file require atleast meson 0.59.0 
 
 project('rt-5gms-application-function', 'c',
-    version : '1.4.3',
+    version : '1.4.4',
     license : '5G-MAG Public',
     meson_version : '>= 0.63.0',
     default_options : [

--- a/subprojects/rt-5gc-service-consumers.wrap
+++ b/subprojects/rt-5gc-service-consumers.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = rt-5gc-service-consumers
 url = https://github.com/5G-MAG/rt-5gc-service-consumers.git
-revision = development
+revision = v1.0.x


### PR DESCRIPTION
The latest release of `rt-5gc-service-consumers` is a v2.0.x release which updates the library compatibility to Open5GS 2.7.2.

In order to maintain compatibility with Open5GS 2.6.4 for the 5GMS Application Function, the branch for the `rt-5gc-service-consumers` needs to be changed to the `v1.0.x` branch. This PR fixes this by changing the referenced branch in the `rt-5gc-service-consumers.wrap` file.

If you are applying this fix to a previously checked out version then you will need to reset the rt-5gc-service-consumers subproject to the v1.0.x branch manually or recreate the subproject directory. To do this either:
```bash
cd ~/rt-5gms-application-function/subprojects/rt-5gc-service-consumers
git fetch
git checkout v1.0.x
```
or
```bash
cd ~/rt-5gms-application-function
rm -rf subprojects/rt-5gc-service-consumers
ninja -C build reconfigure
```