### PR TITLE
Release v1.4.4

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@
 # Meson module fs and its functions like fs.hash_file require atleast meson 0.59.0 
 
 project('rt-5gms-application-function', 'c',
-    version : '1.4.3',
+    version : '1.4.4',
     license : '5G-MAG Public',
     meson_version : '>= 0.63.0',
     default_options : [

--- a/subprojects/rt-5gc-service-consumers.wrap
+++ b/subprojects/rt-5gc-service-consumers.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = rt-5gc-service-consumers
 url = https://github.com/5G-MAG/rt-5gc-service-consumers.git
-revision = development
+revision = v1.0.x


### PR DESCRIPTION
Release of minor bug fix.

This release is just to patch a build issue caused by the updated [rt-5gc-service-consumers](https://github.com/5G-MAG/rt-5gc-service-consumers). The patch was applied to the development branch and tested in #177.
