### PR TITLE
No duplicate external references in Policy Templates and avoid empty ServiceAccessInfo.streamingAccess.

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,3 @@
 option('latest_apis', type: 'boolean', value: false)
-option('fiveg_api_approval', type: 'string', value: '106')
+option('fiveg_api_approval', type: 'string', value: '109')
 option('fiveg_api_release', type: 'string', value: '17')

--- a/src/5gmsaf/msaf-m1-sm.c
+++ b/src/5gmsaf/msaf-m1-sm.c
@@ -622,13 +622,13 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                         }
                                     }
                                 }
-                            }
-                            else if (api == m1_policytemplatesprovisioning_api) {
+                            } else if (api == m1_policytemplatesprovisioning_api) {
                                 cJSON *policy_template =  NULL;
                                 msaf_api_policy_template_t *policy_temp = NULL;
                                 char *pol_temp;
-                                const char *parse_err;
-                                char *err_param;
+                                const char *parse_err = NULL;
+                                char *err_param = NULL;
+                                int err_status = 0;
 
                                 if (!msaf_self()->config.open5gsIntegration_flag) {
                                     const char *err = "Policy Templates are not available on this instance of the 5GMS Application Function.";
@@ -646,7 +646,7 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                 if (policy_temp) {
                                     _policy_template_remove_read_only(policy_temp);
                                     /* add policy template */
-                                    if (msaf_provisioning_session_add_policy_template(msaf_provisioning_session, policy_temp, time(NULL))) {
+                                    if (msaf_provisioning_session_add_policy_template(msaf_provisioning_session, policy_temp, time(NULL), &err_status, &parse_err, (const char**)&err_param)) {
                                         char *location;
                                         msaf_policy_template_node_t *msaf_policy_template;
 
@@ -663,15 +663,22 @@ void msaf_m1_state_functional(ogs_fsm_t *s, msaf_event_t *e)
                                         ogs_assert(response);
                                         ogs_assert(true == ogs_sbi_server_send_response(stream, response));
                                         ogs_free(location);
+                                        ogs_info("policy template id: %s", policy_temp->policy_template_id);
                                     } else {
                                         char *err;
-                                        err = ogs_msprintf("Problem adding the policy template to the provisioning session [%s].", message->h.resource.component[1]);
+                                        if (parse_err) {
+                                            if (err_param) {
+                                                err = ogs_msprintf("Problem adding the policy template to the provisioning session [%s]: problem with field \"%s\": %s", message->h.resource.component[1], err_param, parse_err);
+                                            } else {
+                                                err = ogs_msprintf("Problem adding the policy template to the provisioning session [%s]: %s", message->h.resource.component[1], parse_err);
+                                            }
+                                        } else {
+                                            err = ogs_msprintf("Problem adding the policy template to the provisioning session [%s].", message->h.resource.component[1]);
+                                        }
                                         ogs_error("%s",err);
-                                        ogs_assert(true == nf_server_send_error(stream, 404, 2, message, "Problem adding the policy template.", err, NULL, NULL, api, app_meta));
+                                        ogs_assert(true == nf_server_send_error(stream, err_status, 2, message, "Problem adding the policy template.", err, NULL, NULL, api, app_meta));
                                         ogs_free(err);
-                                   }
-
-                                    ogs_info("policy template id: %s", policy_temp->policy_template_id);
+                                    }
                                 } else {
                                     char *err;
                                     OpenAPI_list_t *invalid_params = NULL;

--- a/src/5gmsaf/policy-template.c
+++ b/src/5gmsaf/policy-template.c
@@ -256,7 +256,6 @@ bool msaf_policy_template_clear(ogs_hash_t *policy_templates)
         ogs_hash_this(hi, &key, &key_len, (void**)(&node));
         ogs_hash_set(policy_templates, key, key_len, NULL);
         msaf_policy_template_node_free(node);
-        ogs_free((void*)key);
     }
 
     return true;

--- a/src/5gmsaf/provisioning-session.c
+++ b/src/5gmsaf/provisioning-session.c
@@ -63,8 +63,6 @@ static msaf_policy_template_change_state_event_data_t *msaf_policy_template_chan
 
 static void msaf_provisioning_session_policy_template_delete(msaf_provisioning_session_t *msaf_provisioning_session, msaf_policy_template_node_t *policy_template_node, msaf_api_policy_template_STATE_e new_state, void *user_data);
 
-static int free_ogs_hash_provisioning_session_policy_template(void *rec, const void *key, int klen, const void *value);
-
 /***** Public functions *****/
 
 msaf_api_content_hosting_configuration_t *
@@ -119,6 +117,7 @@ msaf_provisioning_session_create(const char *provisioning_session_type, const ch
 
     msaf_provisioning_session->metrics_reporting_map = msaf_metrics_reporting_map();
     msaf_provisioning_session->certificate_map = msaf_certificate_map();
+    msaf_provisioning_session->policy_templates_by_external_id = msaf_policy_templates_new();
     msaf_provisioning_session->policy_templates = msaf_policy_templates_new();
     ogs_hash_set(msaf_self()->provisioningSessions_map, msaf_strdup(msaf_provisioning_session->provisioningSessionId), OGS_HASH_KEY_STRING, msaf_provisioning_session);
 
@@ -156,8 +155,15 @@ void msaf_provisioning_session_free(msaf_provisioning_session_t *provisioning_se
     if (provisioning_session->sai_cache)
         msaf_sai_cache_free(provisioning_session->sai_cache);
 
-    if (provisioning_session->policy_templates)
+    if (provisioning_session->policy_templates_by_external_id) {
+        ogs_hash_destroy(provisioning_session->policy_templates_by_external_id);
+        provisioning_session->policy_templates_by_external_id = NULL;
+    }
+
+    if (provisioning_session->policy_templates) {
         msaf_provisioning_session_policy_template_free(provisioning_session->policy_templates);
+        provisioning_session->policy_templates = NULL;
+    }
 
     ogs_list_for_each_safe(&provisioning_session->application_server_states, next_as_state_ref, as_state_ref) {
         ogs_list_remove(&provisioning_session->application_server_states, as_state_ref);
@@ -448,7 +454,7 @@ msaf_provisioning_session_find_by_provisioningSessionId(const char *provisioning
 msaf_policy_template_node_t *
 msaf_provisioning_session_find_policy_template_by_id(msaf_provisioning_session_t *provisioning_session, const char *policy_template_id)
 {
-    if (!provisioning_session->policy_templates)        return NULL;
+    if (!provisioning_session->policy_templates) return NULL;
     return (msaf_policy_template_node_t *) ogs_hash_get(provisioning_session->policy_templates, policy_template_id, OGS_HASH_KEY_STRING);
 }
 
@@ -722,11 +728,16 @@ char *enumerate_provisioning_sessions(void)
 
 }
 
-bool msaf_provisioning_session_add_policy_template(msaf_provisioning_session_t *provisioning_session, msaf_api_policy_template_t *policy_template, time_t creation_time) {
-
+bool msaf_provisioning_session_add_policy_template(msaf_provisioning_session_t *provisioning_session, msaf_api_policy_template_t *policy_template, time_t creation_time, int *result_status, const char **err_msg, const char **err_parameter)
+{
     ogs_uuid_t uuid;
     char id[OGS_UUID_FORMATTED_LENGTH + 1];
     msaf_policy_template_node_t *msaf_policy_template;
+
+    /* clear error return */
+    if (result_status) *result_status = 0;
+    if (err_msg) *err_msg = NULL;
+    if (err_parameter) *err_parameter = NULL;
 
     ogs_uuid_get(&uuid);
     ogs_uuid_format(id, &uuid);
@@ -734,12 +745,28 @@ bool msaf_provisioning_session_add_policy_template(msaf_provisioning_session_t *
     msaf_policy_template_set_id(policy_template, id);
 
     msaf_policy_template = msaf_policy_template_populate(policy_template, creation_time);
-    if (!msaf_policy_template) return false;
-
-    ogs_hash_set(provisioning_session->policy_templates, msaf_strdup(id), OGS_HASH_KEY_STRING, msaf_policy_template);
-
-    if (!msaf_provisioning_session_send_policy_template_state_change_event(provisioning_session, msaf_policy_template, msaf_api_policy_template_STATE_VAL_PENDING, NULL, NULL))
+    if (!msaf_policy_template) {
+        if (result_status) *result_status = 500;
+        if (err_msg) *err_msg = "Resources unavailable when adding a Policy Template";
         return false;
+    }
+
+    if (policy_template->external_reference && ogs_hash_get(provisioning_session->policy_templates_by_external_id, policy_template->external_reference, OGS_HASH_KEY_STRING)) {
+        if (result_status) *result_status = 403;
+        if (err_msg) *err_msg = "Duplicate policy template external reference in provisioning session";
+        if (err_parameter) *err_parameter = "externalReference";
+        msaf_policy_template_node_free(msaf_policy_template);
+        return false;
+    }
+
+    ogs_hash_set(provisioning_session->policy_templates_by_external_id, policy_template->external_reference, OGS_HASH_KEY_STRING, msaf_policy_template);
+    ogs_hash_set(provisioning_session->policy_templates, policy_template->policy_template_id, OGS_HASH_KEY_STRING, msaf_policy_template);
+
+    if (!msaf_provisioning_session_send_policy_template_state_change_event(provisioning_session, msaf_policy_template, msaf_api_policy_template_STATE_VAL_PENDING, NULL, NULL)) {
+        if (result_status) *result_status = 500;
+        if (err_msg) *err_msg = "Event queue full when adding a Policy Template";
+        return false;
+    }
 
     return true;
 
@@ -757,8 +784,9 @@ bool msaf_provisioning_session_update_policy_template(msaf_provisioning_session_
     msaf_policy_template_free(msaf_policy_template->policy_template);
     msaf_policy_template->policy_template = policy_template;
     msaf_policy_template->policy_template->policy_template_id = policy_template_id;
-    if (!msaf_provisioning_session_send_policy_template_state_change_event(provisioning_session, msaf_policy_template, msaf_api_policy_template_STATE_VAL_PENDING, NULL, NULL))
+    if (!msaf_provisioning_session_send_policy_template_state_change_event(provisioning_session, msaf_policy_template, msaf_api_policy_template_STATE_VAL_PENDING, NULL, NULL)) {
         return false;
+    }
 
     return true;
 }
@@ -864,27 +892,15 @@ static void msaf_provisioning_session_policy_template_delete(msaf_provisioning_s
     ogs_assert(policy_template_node);
     ogs_assert(user_data);
 
-    ogs_hash_do(free_ogs_hash_provisioning_session_policy_template, user_data, msaf_provisioning_session->policy_templates);
-}
-
-static int
-free_ogs_hash_provisioning_session_policy_template(void *rec, const void *key, int klen, const void *value)
-{
-
     msaf_provisioning_session_policy_template_delete_data_t *msaf_provisioning_session_policy_template_delete_data =
-                (msaf_provisioning_session_policy_template_delete_data_t *)rec;
-    msaf_provisioning_session_t *provisioning_session = msaf_provisioning_session_policy_template_delete_data->provisioning_session;
+                (msaf_provisioning_session_policy_template_delete_data_t *)user_data;
     msaf_policy_template_node_t *msaf_policy_template = msaf_provisioning_session_policy_template_delete_data->policy_template;
 
-/*    if (!strcmp(msaf_policy_template->policy_template->policy_template_id, (char *)key)) {*/
-    if (value == msaf_policy_template) {
-        msaf_policy_template_node_free(msaf_policy_template);
-        ogs_hash_set(provisioning_session->policy_templates, key, klen, NULL);
-        ogs_free((void*)key);
-        return 0; /* finish search when the first key matches */
-    }
-
-    return 1;
+    if (msaf_policy_template->policy_template->external_reference)
+        ogs_hash_set(msaf_provisioning_session->policy_templates_by_external_id, msaf_policy_template->policy_template->external_reference, OGS_HASH_KEY_STRING, NULL);
+    ogs_hash_set(msaf_provisioning_session->policy_templates, msaf_policy_template->policy_template->policy_template_id, OGS_HASH_KEY_STRING, NULL);
+    msaf_policy_template_node_free(msaf_policy_template);
+    ogs_free(user_data);
 }
 
 static void safe_ogs_free(void *ptr)

--- a/src/5gmsaf/provisioning-session.h
+++ b/src/5gmsaf/provisioning-session.h
@@ -52,6 +52,7 @@ typedef struct msaf_provisioning_session_s {
     } httpMetadata;
     ogs_hash_t *certificate_map;          //Type: char* => n/a (just used as a set - external tool manages data)
     ogs_hash_t *policy_templates; /* key: policy template id, value: msaf_policy_template_node_t */
+    ogs_hash_t *policy_templates_by_external_id; /* key: external policy id, value: msaf_policy_template_node_t (not owned) */
     ogs_hash_t *metrics_reporting_map;
     ogs_list_t application_server_states; //Type: msaf_application_server_state_ref_node_t*
     int marked_for_deletion;
@@ -106,7 +107,7 @@ extern cJSON *msaf_get_content_hosting_configuration_by_provisioning_session_id(
 
 extern char *enumerate_provisioning_sessions(void);
 
-extern bool msaf_provisioning_session_add_policy_template(msaf_provisioning_session_t *provisioning_session, msaf_api_policy_template_t *policy_template, time_t creation_time);
+extern bool msaf_provisioning_session_add_policy_template(msaf_provisioning_session_t *provisioning_session, msaf_api_policy_template_t *policy_template, time_t creation_time, int *result_status, const char **err_msg, const char **err_parameter);
 
 extern bool msaf_provisioning_session_delete_policy_template(msaf_provisioning_session_t *provisioning_session, msaf_policy_template_node_t *policy_template);
 

--- a/src/5gmsaf/service-access-information.c
+++ b/src/5gmsaf/service-access-information.c
@@ -72,8 +72,10 @@ msaf_context_service_access_information_create(msaf_provisioning_session_t *prov
                 OpenAPI_list_add(entry_points, m5_entry);
             }
         }
+        if (entry_points) {
+            streaming_access = msaf_api_service_access_information_resource_streaming_access_create(entry_points, NULL);
+        }
     }
-    streaming_access = msaf_api_service_access_information_resource_streaming_access_create(entry_points, NULL);
 
     // Dynamic policy invocation configuration
     if (provisioning_session->policy_templates) {


### PR DESCRIPTION
This PR prevents a new *Policy Template* being created via the API at reference point M1 when a *Policy Template* is already defined for a *Provisioning Session* with the same `externalReference`.

Fixes #179 

This also includes an old fix for empty ServiceAccessInfo.streamingAccess objects in responses on M5 and an update to SA#109 versions of the API (no change since the last release at SA#106).

