### PR TITLE
fix PUT Policy Templeate for issue #182

### DIFF
--- a/src/5gmsaf/provisioning-session.c
+++ b/src/5gmsaf/provisioning-session.c
@@ -779,7 +779,8 @@ bool msaf_provisioning_session_update_policy_template(msaf_provisioning_session_
     ogs_assert(msaf_policy_template);
     ogs_assert(policy_template);
 
-    policy_template_id = msaf_strdup(msaf_policy_template->policy_template->policy_template_id);
+    policy_template_id = msaf_policy_template->policy_template->policy_template_id;
+    msaf_policy_template->policy_template->policy_template_id = NULL;
 
     msaf_policy_template_free(msaf_policy_template->policy_template);
     msaf_policy_template->policy_template = policy_template;


### PR DESCRIPTION
The policy_template_id string is freed when `msaf_policy_template_free(msaf_policy_template->policy_template)` runs.
Inside `msaf_api_policy_template_free`, we call `ogs_free(msaf_api_policy_template->policy_template_id)`, which releases the allocated memory for the ID.

However, the hash table stores only the pointer as the key and does not copy the string.
So after the free, the hash key still points to freed memory.
When `msaf_provisioning_session_find_policy_template_by_id` calls `ogs_hash_get(...)`, the lookup compares against invalid memory, so the entry can no longer be found.

Since the last PR, the hash key is now taken directly from `policy_template->policy_template_id`.
As a result, freeing the policy template also invalidates the hash key.