### PR TITLE
Update README installation steps for newer Linux distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,7 @@ A setup comprising the 5GMSd AF and 5GMSd AS based on Docker Compose can be foun
 ## Install dependencies
 
 ```bash
-sudo apt install git python3-pip python3-venv python3-setuptools python3-wheel ninja-build build-essential flex bison git libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libnghttp2-dev libtins-dev libtalloc-dev libpcre2-dev curl wget default-jdk cmake
-sudo python3 -m pip install meson
-python3 -m pip install build pyOpenSSL
+sudo apt install git python3-pip python3-venv python3-setuptools python3-wheel ninja-build build-essential flex bison libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libtins-dev libtalloc-dev libpcre2-dev curl wget default-jdk cmake
 ```
 
 ## Downloading
@@ -54,6 +52,17 @@ git clone --recurse-submodules https://github.com/5G-MAG/rt-5gms-application-fun
 cd rt-5gms-application-function
 git submodule update
 ```
+## Python environment
+
+Create a repository-local virtual environment and install the Python build tooling:
+
+```bash
+cd ~/rt-5gms-application-function
+python3 -m venv .venv
+. .venv/bin/activate
+python3 -m pip install --upgrade pip
+python3 -m pip install meson build pyOpenSSL
+```
 
 ## Building
 
@@ -63,8 +72,9 @@ To build the 5GMS Application Function from the source:
 
 ```bash
 cd ~/rt-5gms-application-function
-meson build
-ninja -C build
+. .venv/bin/activate
+meson setup build
+meson compile -C build
 ```
 
 **Note:** Errors during the `meson build` command are often caused by missing dependencies or a network issue while
@@ -77,9 +87,12 @@ trying to retrieve the API files and `openapi-generator` JAR file. See the
 To install the built Application Function as a system process:
 
 ```bash
-cd ~/rt-5gms-application-function/build
-sudo meson install --no-rebuild
+cd ~/rt-5gms-application-function
+sudo ./.venv/bin/meson install -C build --no-rebuild
 ```
+
+The install step must use the same Meson executable that created the `build` directory. Running
+`sudo meson install` may pick a different system Meson version and fail with a build directory version mismatch.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -36,42 +36,7 @@ A setup comprising the 5GMSd AF and 5GMSd AS based on Docker Compose can be foun
 
 ```bash
 sudo apt update
-sudo apt install \
-    bison \
-    build-essential \
-    cmake \
-    curl \
-    default-jdk \
-    flex \
-    git \
-    libbson-dev \
-    libcurl4-gnutls-dev \
-    libgcrypt-dev \
-    libgnutls28-dev \
-    libidn11-dev \
-    libmicrohttpd-dev \
-    libmongoc-dev \
-    libnghttp2-dev \
-    libpcre2-dev \
-    libsctp-dev \
-    libssl-dev \
-    libtalloc-dev \
-    libtins-dev \
-    libyaml-dev \
-    meson \
-    ninja-build \
-    python3-aiofiles \
-    python3-build \
-    python3-h11 \
-    python3-h2 \
-    python3-httpx \
-    python3-openssl \
-    python3-pip \
-    python3-setuptools \
-    python3-venv \
-    python3-wheel \
-    python3-yaml \
-    wget
+sudo apt install bison build-essential cmake curl default-jdk flex git libbson-dev libcurl4-gnutls-dev libgcrypt-dev libgnutls28-dev libidn11-dev libmicrohttpd-dev libmongoc-dev libnghttp2-dev libpcre2-dev libsctp-dev libssl-dev libtalloc-dev libtins-dev libyaml-dev meson ninja-build python3-aiofiles python3-build python3-h11 python3-h2 python3-httpx python3-openssl python3-pip python3-setuptools python3-venv python3-wheel python3-yaml wget
 ```
 
 ## Downloading

--- a/README.md
+++ b/README.md
@@ -35,7 +35,43 @@ A setup comprising the 5GMSd AF and 5GMSd AS based on Docker Compose can be foun
 ## Install dependencies
 
 ```bash
-sudo apt install git python3-pip python3-venv python3-setuptools python3-wheel ninja-build build-essential flex bison libsctp-dev libgnutls28-dev libgcrypt-dev libssl-dev libidn11-dev libmongoc-dev libbson-dev libyaml-dev libnghttp2-dev libmicrohttpd-dev libcurl4-gnutls-dev libtins-dev libtalloc-dev libpcre2-dev curl wget default-jdk cmake
+sudo apt update
+sudo apt install \
+    bison \
+    build-essential \
+    cmake \
+    curl \
+    default-jdk \
+    flex \
+    git \
+    libbson-dev \
+    libcurl4-gnutls-dev \
+    libgcrypt-dev \
+    libgnutls28-dev \
+    libidn11-dev \
+    libmicrohttpd-dev \
+    libmongoc-dev \
+    libnghttp2-dev \
+    libpcre2-dev \
+    libsctp-dev \
+    libssl-dev \
+    libtalloc-dev \
+    libtins-dev \
+    libyaml-dev \
+    meson \
+    ninja-build \
+    python3-aiofiles \
+    python3-build \
+    python3-h11 \
+    python3-h2 \
+    python3-httpx \
+    python3-openssl \
+    python3-pip \
+    python3-setuptools \
+    python3-venv \
+    python3-wheel \
+    python3-yaml \
+    wget
 ```
 
 ## Downloading
@@ -52,17 +88,6 @@ git clone --recurse-submodules https://github.com/5G-MAG/rt-5gms-application-fun
 cd rt-5gms-application-function
 git submodule update
 ```
-## Python environment
-
-Create a repository-local virtual environment and install the Python build tooling:
-
-```bash
-cd ~/rt-5gms-application-function
-python3 -m venv .venv
-. .venv/bin/activate
-python3 -m pip install --upgrade pip
-python3 -m pip install meson build pyOpenSSL
-```
 
 ## Building
 
@@ -72,9 +97,8 @@ To build the 5GMS Application Function from the source:
 
 ```bash
 cd ~/rt-5gms-application-function
-. .venv/bin/activate
-meson setup build
-meson compile -C build
+meson build
+ninja -C build
 ```
 
 **Note:** Errors during the `meson build` command are often caused by missing dependencies or a network issue while
@@ -88,11 +112,11 @@ To install the built Application Function as a system process:
 
 ```bash
 cd ~/rt-5gms-application-function
-sudo ./.venv/bin/meson install -C build --no-rebuild
-```
+sudo meson install --no-rebuild -C build
 
-The install step must use the same Meson executable that created the `build` directory. Running
-`sudo meson install` may pick a different system Meson version and fail with a build directory version mismatch.
+sudo mkdir -p /usr/local/var/log/open5gs/reports
+sudo chmod -R 777 /usr/local/var/log/open5gs/reports
+```
 
 ## Running
 


### PR DESCRIPTION

This PR updates the README installation instructions so they work again on newer Linux distributions.

The current README no longer works cleanly. In particular, the documented Python installation steps fail because newer distributions enforce PEP 668 and use an externally managed Python environment. As a result, global pip installations such as `sudo python3 -m pip install meson` and `python3 -m pip install build pyOpenSSL` are rejected. 

```
sudo python3 -m pip install meson
python3 -m pip install build pyOpenSSL

error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

This PR also fixes the Meson installation step described in the README. Running `sudo meson install --no-rebuild` does not necessarily use the same Meson version that was used to generate the build directory. This can cause a version mismatch error when the install step uses a different Meson version than the one used to generate the build directory.

```
erik@FAME-1000658274-L14:~/rt-5gms-application-function$ cd ~/rt-5gms-application-function/build
sudo meson install --no-rebuild

ERROR: Build directory has been generated with Meson version 1.7.0, which is incompatible with the current version 1.11.1. Consider reconfiguring the directory with "meson setup --reconfigure".
```